### PR TITLE
Implement knowledge base retrieval helper

### DIFF
--- a/app/rag.py
+++ b/app/rag.py
@@ -1,5 +1,63 @@
+"""Lightweight retrieval helper used by the AI assistant.
+
+This module provides a very small abstraction over the more feature rich
+``knowledge_base`` module.  The original repository shipped with a stub
+implementation that always returned an empty string which meant the assistant
+never had any additional context to augment its responses with.  For the
+initial step of building out the application we wire this function up to the
+existing knowledge base search helpers.
+
+`retrieve_context_snippets` now queries the knowledge base and returns the
+top matching document contents joined together as a single string.  The
+function is intentionally resilient: any errors from the knowledge base layer
+are caught and logged and an empty string is returned so callers can continue
+gracefully even when the vector store is unavailable.
+"""
+
 from __future__ import annotations
+
+import logging
 from typing import List
+
+
+logger = logging.getLogger(__name__)
+
+
 def retrieve_context_snippets(query: str, top_k: int = 5) -> str:
-    # TODO: plug your Chroma/pgvector retrieval here
-    return ""
+    """Return relevant context snippets for a query.
+
+    The knowledge base returns a list of dictionaries containing a ``content``
+    field.  We extract the content from each result and join them with blank
+    lines so the caller can feed the text to the language model.
+
+    If the knowledge base cannot be queried (for example when the OpenAI API
+    key is not configured) the function will simply return an empty string.
+
+    Args:
+        query: Natural language query describing the context you are looking
+            for.
+        top_k: Maximum number of snippets to return.
+
+    Returns:
+        A string containing the top matching snippets separated by two newlines.
+    """
+
+    try:
+        # Import here to avoid importing heavy optional dependencies when the
+        # knowledge base is not used.  This also makes unit testing easier
+        # because the function can be exercised without the chromadb package
+        # installed.
+        from .knowledge_base import query_knowledge_base
+
+        results = query_knowledge_base(query, top_k=top_k)
+    except Exception as exc:  # pragma: no cover - defensive programming
+        logger.error("Knowledge base query failed: %s", exc)
+        return ""
+
+    snippets: List[str] = []
+    for result in results:
+        content = result.get("content") if isinstance(result, dict) else None
+        if content:
+            snippets.append(str(content).strip())
+
+    return "\n\n".join(snippets)

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -1,0 +1,29 @@
+import os
+import sys
+
+import pytest
+
+# Ensure repository root is on the Python path so the ``app`` package can be
+# imported when tests are executed in isolation.
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import app.rag as rag
+
+
+def test_retrieve_context_snippets(monkeypatch):
+    """retrieve_context_snippets returns joined snippet contents."""
+
+    def fake_query_knowledge_base(query, top_k=5, doc_type=None):
+        return [
+            {"content": "alpha"},
+            {"content": "beta"},
+        ]
+
+    # Inject a lightweight stand-in for ``app.knowledge_base`` so that the
+    # function's dynamic import resolves to our fake implementation.
+    fake_module = type(sys)("app.knowledge_base")
+    fake_module.query_knowledge_base = fake_query_knowledge_base
+    monkeypatch.setitem(sys.modules, "app.knowledge_base", fake_module)
+
+    result = rag.retrieve_context_snippets("irrelevant", top_k=2)
+    assert result == "alpha\n\nbeta"


### PR DESCRIPTION
## Summary
- connect RAG retrieval to knowledge base for contextual snippets
- add unit test for context snippet assembly

## Testing
- `pytest tests/test_rag.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68953663899c8323b4cad1ba04450bee