### PR TITLE
Add CI build status polling and overlay notifications

### DIFF
--- a/app/realtime.py
+++ b/app/realtime.py
@@ -354,6 +354,21 @@ def get_session_manager() -> RealtimeSessionManager:
     return session_manager
 
 
+def broadcast_event(event_type: str, data: Dict[str, Any]):
+    """Broadcast a custom event to all connected clients"""
+    message = {
+        'type': event_type,
+        'data': data
+    }
+
+    for session in session_manager.sessions.values():
+        for client_queue in session.client_queues.values():
+            try:
+                client_queue.put(json.dumps(message))
+            except Exception as e:
+                log.error(f"Failed to broadcast {event_type}: {e}")
+
+
 # Backward compatibility functions for existing API
 def get_or_create_session(meeting_id: str, ic_level: str = "IC6"):
     """Backward compatibility: create session using new manager"""

--- a/backend/build_status_service.py
+++ b/backend/build_status_service.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+import os
+import time
+import threading
+import logging
+from typing import Dict, Any
+import requests
+import subprocess
+
+from app.realtime import broadcast_event
+
+log = logging.getLogger(__name__)
+
+
+class BuildStatusService:
+    """Polls GitHub/GitLab build APIs and notifies on status changes."""
+
+    def __init__(self, poll_interval: int = 60):
+        self.poll_interval = poll_interval
+        self.running = False
+        self.thread: threading.Thread | None = None
+        self.github_token = os.getenv("GITHUB_TOKEN", "")
+        self.gitlab_token = os.getenv("GITLAB_TOKEN", "")
+        self.github_repo = os.getenv("GITHUB_REPO")  # e.g. owner/repo
+        self.gitlab_project = os.getenv("GITLAB_PROJECT")  # numeric project id
+        self._last_status: Dict[str, str] = {}
+
+    def start(self):
+        if self.running:
+            return
+        self.running = True
+        self.thread = threading.Thread(target=self._run, daemon=True)
+        self.thread.start()
+        log.info("BuildStatusService started")
+
+    def stop(self):
+        self.running = False
+
+    def _run(self):
+        while self.running:
+            try:
+                if self.github_repo:
+                    self._check_github()
+                if self.gitlab_project:
+                    self._check_gitlab()
+            except Exception as e:
+                log.error(f"Build status polling error: {e}")
+            time.sleep(self.poll_interval)
+
+    # --- GitHub ---
+    def _gh_headers(self) -> Dict[str, str]:
+        headers = {"Accept": "application/vnd.github+json"}
+        if self.github_token:
+            headers["Authorization"] = f"Bearer {self.github_token}"
+        return headers
+
+    def _check_github(self):
+        owner, repo = self.github_repo.split("/")
+        r = requests.get(
+            f"https://api.github.com/repos/{owner}/{repo}/pulls",
+            headers=self._gh_headers(),
+        )
+        r.raise_for_status()
+        for pr in r.json():
+            sha = pr.get("head", {}).get("sha")
+            if not sha:
+                continue
+            status_resp = requests.get(
+                f"https://api.github.com/repos/{owner}/{repo}/commits/{sha}/status",
+                headers=self._gh_headers(),
+            )
+            status_resp.raise_for_status()
+            state = status_resp.json().get("state")
+            key = f"github:{pr['number']}"
+            if state and self._last_status.get(key) != state:
+                self._last_status[key] = state
+                self._handle_status(
+                    source="github",
+                    pr_number=pr["number"],
+                    status=state,
+                    title=pr.get("title"),
+                    url=pr.get("html_url"),
+                )
+
+    # --- GitLab ---
+    def _gl_headers(self) -> Dict[str, str]:
+        headers: Dict[str, str] = {}
+        if self.gitlab_token:
+            headers["PRIVATE-TOKEN"] = self.gitlab_token
+        return headers
+
+    def _check_gitlab(self):
+        project = self.gitlab_project
+        r = requests.get(
+            f"https://gitlab.com/api/v4/projects/{project}/merge_requests?state=opened",
+            headers=self._gl_headers(),
+        )
+        r.raise_for_status()
+        for mr in r.json():
+            iid = mr.get("iid")
+            if iid is None:
+                continue
+            pipes = requests.get(
+                f"https://gitlab.com/api/v4/projects/{project}/merge_requests/{iid}/pipelines",
+                headers=self._gl_headers(),
+            )
+            pipes.raise_for_status()
+            if not pipes.json():
+                continue
+            latest = pipes.json()[0]
+            status = latest.get("status")
+            key = f"gitlab:{iid}"
+            if status and self._last_status.get(key) != status:
+                self._last_status[key] = status
+                self._handle_status(
+                    source="gitlab",
+                    pr_number=iid,
+                    status=status,
+                    title=mr.get("title"),
+                    url=mr.get("web_url"),
+                )
+
+    # --- handling ---
+    def _handle_status(self, source: str, pr_number: int, status: str, title: str | None, url: str | None):
+        info: Dict[str, Any] = {
+            "source": source,
+            "pr_number": pr_number,
+            "status": status,
+            "title": title,
+            "url": url,
+        }
+        broadcast_event("build_status", info)
+        log.info(f"Build status changed: {info}")
+        if status.lower() in ("failure", "failed"):
+            self._rerun_tests()
+
+    def _rerun_tests(self):
+        try:
+            log.info("Re-running tests due to build failure")
+            subprocess.run(["pytest"], check=False)
+        except Exception as e:
+            log.error(f"Failed to run tests: {e}")

--- a/ide_plugin/src/sessionManager.ts
+++ b/ide_plugin/src/sessionManager.ts
@@ -129,6 +129,9 @@ export class InterviewSessionManager {
             case 'session_ended':
                 this.endSession();
                 break;
+            case 'build_status':
+                this.handleBuildStatus(data.data);
+                break;
         }
     }
 
@@ -151,6 +154,20 @@ export class InterviewSessionManager {
 
         this.updateStatusBar('Connected', this.answers.length);
         this.onAnswersUpdated.fire(this.answers);
+    }
+
+    private handleBuildStatus(info: any) {
+        const message = `Build ${info.status} for PR #${info.pr_number}: ${info.title || ''}`;
+        vscode.window.showWarningMessage(message);
+        if (info.status && info.status.toLowerCase().includes('fail')) {
+            this.runTests();
+        }
+    }
+
+    private runTests() {
+        const terminal = vscode.window.createTerminal('CI Tests');
+        terminal.show();
+        terminal.sendText('pytest || true');
     }
 
     private showNewAnswerNotification(answer: Answer) {

--- a/overlay/overlay_client.js
+++ b/overlay/overlay_client.js
@@ -216,6 +216,9 @@ class SmartOverlayClient {
             case 'keepalive':
                 // Keep connection alive
                 break;
+            case 'build_status':
+                this.showBuildStatus(data.data);
+                break;
         }
     }
 
@@ -237,6 +240,14 @@ class SmartOverlayClient {
             // Historical answer, just update counter
             this.updateAnswerCounter();
         }
+    }
+
+    showBuildStatus(info) {
+        const color = info.status === 'success' ? '#4caf50' : '#ff5555';
+        const msg = `Build ${info.status} for PR #${info.pr_number}: ${info.title || ''}`;
+        this.answerDisplay.innerHTML = `<div style="color:${color};">${this.escapeHtml(msg)}</div>`;
+        this.show();
+        this.updateStatus(`Build ${info.status}`, info.status === 'success' ? 'success' : 'error');
     }
 
     displayCurrentAnswer() {

--- a/web_interface.py
+++ b/web_interface.py
@@ -2,10 +2,15 @@ import os, json, time, logging
 from flask import Flask, request, jsonify, Response
 from flask_cors import CORS
 from app.realtime import get_or_create_session, push_caption, pop_event_generator, get_session_manager
+from backend.build_status_service import BuildStatusService
 
 app = Flask(__name__)
 CORS(app)
 logging.basicConfig(level=logging.INFO)
+
+# Start build status service to monitor CI systems
+build_status_service = BuildStatusService()
+build_status_service.start()
 
 @app.route('/api/health', methods=['GET'])
 def health():


### PR DESCRIPTION
## Summary
- broadcast custom events to all real-time sessions
- poll GitHub and GitLab builds, notify on status changes and rerun tests
- surface build status in browser overlay and IDE plugin

## Testing
- `npm run compile` *(fails: Cannot find name 'EventSource')*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689568ed16cc8323b0701222fcda0a92