### PR TITLE
Add issue/PR operations with dry-run toggles

### DIFF
--- a/app/integrations/github_client.py
+++ b/app/integrations/github_client.py
@@ -5,8 +5,10 @@ from typing import Optional, Dict, Any
 GITHUB_API = os.getenv('GITHUB_API', 'https://api.github.com')
 
 class GitHubClient:
-    def __init__(self, token_env: str = 'GITHUB_TOKEN', dry_run: bool = True):
+    def __init__(self, token_env: str = 'GITHUB_TOKEN', dry_run: Optional[bool] = None):
         self.token = os.getenv(token_env, '')
+        if dry_run is None:
+            dry_run = os.getenv('GITHUB_DRY_RUN', 'true').lower() != 'false'
         self.dry_run = dry_run
 
     def _headers(self):
@@ -20,5 +22,37 @@ class GitHubClient:
             return {'dry_run': True, 'title': title, 'head': head, 'base': base}
         url = f"{GITHUB_API}/repos/{owner}/{repo}/pulls"
         r = requests.post(url, headers=self._headers(), json={'title': title, 'head': head, 'base': base, 'body': body})
+        r.raise_for_status()
+        return r.json()
+
+    def get_issue(self, owner: str, repo: str, issue_number: int) -> Dict[str, Any]:
+        if self.dry_run:
+            return {'dry_run': True, 'issue': issue_number}
+        url = f"{GITHUB_API}/repos/{owner}/{repo}/issues/{issue_number}"
+        r = requests.get(url, headers=self._headers())
+        r.raise_for_status()
+        return r.json()
+
+    def update_issue_status(self, owner: str, repo: str, issue_number: int, state: str) -> Dict[str, Any]:
+        if self.dry_run:
+            return {'dry_run': True, 'issue': issue_number, 'state': state}
+        url = f"{GITHUB_API}/repos/{owner}/{repo}/issues/{issue_number}"
+        r = requests.patch(url, headers=self._headers(), json={'state': state})
+        r.raise_for_status()
+        return r.json()
+
+    def get_pr_comments(self, owner: str, repo: str, pr_number: int) -> Dict[str, Any]:
+        if self.dry_run:
+            return {'dry_run': True, 'pr': pr_number}
+        url = f"{GITHUB_API}/repos/{owner}/{repo}/issues/{pr_number}/comments"
+        r = requests.get(url, headers=self._headers())
+        r.raise_for_status()
+        return r.json()
+
+    def post_pr_comment(self, owner: str, repo: str, pr_number: int, body: str) -> Dict[str, Any]:
+        if self.dry_run:
+            return {'dry_run': True, 'pr': pr_number, 'body': body}
+        url = f"{GITHUB_API}/repos/{owner}/{repo}/issues/{pr_number}/comments"
+        r = requests.post(url, headers=self._headers(), json={'body': body})
         r.raise_for_status()
         return r.json()

--- a/app/integrations/jira_client.py
+++ b/app/integrations/jira_client.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 import os, requests
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 
 class JiraClient:
-    def __init__(self):
+    def __init__(self, dry_run: Optional[bool] = None):
         self.base = os.getenv('JIRA_BASE_URL', '')
         self.user = os.getenv('JIRA_USER', '')
         self.token = os.getenv('JIRA_TOKEN', '')
-        self.dry_run = True  # flip when approved
+        if dry_run is None:
+            dry_run = os.getenv('JIRA_DRY_RUN', 'true').lower() != 'false'
+        self.dry_run = dry_run
 
     def _headers(self):
         return {'Authorization': f'Basic {self.user}:{self.token}', 'Content-Type': 'application/json'}
@@ -18,5 +20,21 @@ class JiraClient:
         url = f"{self.base}/rest/api/3/issue"
         payload = {'fields': {'project': {'key': project_key}, 'summary': summary, 'issuetype': {'name': 'Task'}, 'description': description}}
         r = requests.post(url, headers=self._headers(), json=payload)
+        r.raise_for_status()
+        return r.json()
+
+    def get_issue(self, issue_key: str) -> Dict[str, Any]:
+        if self.dry_run:
+            return {'dry_run': True, 'issue': issue_key}
+        url = f"{self.base}/rest/api/3/issue/{issue_key}"
+        r = requests.get(url, headers=self._headers())
+        r.raise_for_status()
+        return r.json()
+
+    def transition_issue(self, issue_key: str, transition_id: str) -> Dict[str, Any]:
+        if self.dry_run:
+            return {'dry_run': True, 'issue': issue_key, 'transition': transition_id}
+        url = f"{self.base}/rest/api/3/issue/{issue_key}/transitions"
+        r = requests.post(url, headers=self._headers(), json={'transition': {'id': transition_id}})
         r.raise_for_status()
         return r.json()


### PR DESCRIPTION
## Summary
- add GET/POST helpers for GitHub issues, status updates, and PR comments
- add Jira issue retrieval and transition methods
- introduce env-driven dry-run flags for GitHub and Jira clients

## Testing
- `pytest`
- `python -m py_compile app/integrations/github_client.py app/integrations/jira_client.py`


------
https://chatgpt.com/codex/tasks/task_e_689568e7ae688323a2b9abc1d18aef26