### PR TITLE
feat: persist meeting sessions to sqlite store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,9 @@ data/user_*.json
 # Environment variables
 .env
 
+# SQLite session storage
+meeting_sessions.db
+
 # Node modules (for browser extension development)
 node_modules/
 

--- a/app/ai_assistant.py
+++ b/app/ai_assistant.py
@@ -13,6 +13,7 @@ import logging
 import os
 import threading
 import time
+import sqlite3
 from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Any
 from dataclasses import dataclass, asdict
@@ -79,6 +80,66 @@ class MeetingSession:
     screen_sharing: bool
     topics_discussed: List[str]
 
+    def to_dict(self) -> Dict[str, Any]:
+        data = asdict(self)
+        data["conversations"] = [asdict(c) for c in self.conversations]
+        return data
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict())
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "MeetingSession":
+        data["conversations"] = [ConversationEntry(**c) for c in data.get("conversations", [])]
+        return cls(**data)
+
+    @classmethod
+    def from_json(cls, data: str) -> "MeetingSession":
+        return cls.from_dict(json.loads(data))
+
+    def save(self, store: "SessionStore") -> None:
+        store.save(self)
+
+    @classmethod
+    def load(cls, session_id: str, store: "SessionStore") -> Optional["MeetingSession"]:
+        return store.load(session_id)
+
+
+class SessionStore:
+    """Simple SQLite store for meeting sessions."""
+
+    def __init__(self, db_path: str = "meeting_sessions.db") -> None:
+        self.conn = sqlite3.connect(db_path, check_same_thread=False)
+        self._init_db()
+
+    def _init_db(self) -> None:
+        cur = self.conn.cursor()
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS sessions (
+                session_id TEXT PRIMARY KEY,
+                data TEXT NOT NULL
+            )
+            """
+        )
+        self.conn.commit()
+
+    def save(self, session: MeetingSession) -> None:
+        cur = self.conn.cursor()
+        cur.execute(
+            "REPLACE INTO sessions (session_id, data) VALUES (?, ?)",
+            (session.session_id, session.to_json()),
+        )
+        self.conn.commit()
+
+    def load(self, session_id: str) -> Optional[MeetingSession]:
+        cur = self.conn.cursor()
+        cur.execute("SELECT data FROM sessions WHERE session_id = ?", (session_id,))
+        row = cur.fetchone()
+        if row:
+            return MeetingSession.from_json(row[0])
+        return None
+
 
 class ConversationMemory:
     """Persistent conversation memory system."""
@@ -87,6 +148,7 @@ class ConversationMemory:
         self.sessions: Dict[str, MeetingSession] = {}
         self.active_session: Optional[str] = None
         self.kb = KnowledgeBase()
+        self.store = SessionStore()
         
     def start_session(self, session_id: str, context: Dict[str, Any]) -> str:
         """Start a new conversation session."""
@@ -103,9 +165,10 @@ class ConversationMemory:
             screen_sharing=context.get('screen_sharing', False),
             topics_discussed=[]
         )
-        
+
         self.sessions[session_id] = session
         self.active_session = session_id
+        session.save(self.store)
         
         logger.info(f"Started conversation session: {session_id}")
         return session_id
@@ -114,7 +177,7 @@ class ConversationMemory:
         """Add conversation entry to session."""
         if session_id in self.sessions:
             self.sessions[session_id].conversations.append(entry)
-            
+
             # Add to knowledge base for long-term memory
             metadata = {
                 "type": "conversation",
@@ -124,13 +187,32 @@ class ConversationMemory:
                 "meeting_context": json.dumps(entry.context)
             }
             self.kb.add_document(entry.content, metadata)
+            self.sessions[session_id].save(self.store)
+
+    def add_action_item(self, session_id: str, item: str) -> None:
+        if session_id in self.sessions:
+            self.sessions[session_id].action_items.append(item)
+            self.sessions[session_id].save(self.store)
+
+    def add_decision(self, session_id: str, decision: str) -> None:
+        if session_id in self.sessions:
+            self.sessions[session_id].decisions.append(decision)
+            self.sessions[session_id].save(self.store)
+
+    def load_session(self, session_id: str) -> Optional[MeetingSession]:
+        session = MeetingSession.load(session_id, self.store)
+        if session:
+            self.sessions[session_id] = session
+        return session
             
     def get_session_context(self, session_id: str) -> Dict[str, Any]:
         """Get full context for a session."""
         if session_id not in self.sessions:
-            return {}
-            
-        session = self.sessions[session_id]
+            session = self.load_session(session_id)
+            if not session:
+                return {}
+        else:
+            session = self.sessions[session_id]
         return {
             "current_session": asdict(session),
             "recent_conversations": [asdict(c) for c in session.conversations[-10:]],


### PR DESCRIPTION
## Summary
- add SQLite-based SessionStore to persist meeting sessions
- serialize MeetingSession objects and load/save them through the store
- capture action items and decisions for long-term recall

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689568e4415483239e48b99d755dbf1a