### PR TITLE
Validate RAG snippet retrieval results

### DIFF
--- a/app/rag.py
+++ b/app/rag.py
@@ -1,5 +1,55 @@
 from __future__ import annotations
-from typing import List
-def retrieve_context_snippets(query: str, top_k: int = 5) -> str:
+
+import logging
+from typing import Any, Dict, List, Optional
+
+
+logger = logging.getLogger(__name__)
+
+
+def retrieve_context_snippets(
+    query: str,
+    top_k: int = 5,
+    results: Optional[List[Dict[str, Any]]] = None,
+) -> str:
+    """Retrieve context snippets for a query.
+
+    Parameters
+    ----------
+    query:
+        The query string used for retrieval.
+    top_k:
+        Maximum number of snippets to return.
+    results:
+        Optional list of pre-fetched results. Each result is expected to have a
+        non-empty ``content`` field.
+
+    Returns
+    -------
+    str
+        The concatenated context snippets separated by newlines.
+
+    Raises
+    ------
+    ValueError
+        If no valid snippets remain after validation.
+    """
+
     # TODO: plug your Chroma/pgvector retrieval here
-    return ""
+    if results is None:
+        results = []
+
+    valid_snippets: List[str] = []
+    for idx, item in enumerate(results):
+        content = item.get("content") if isinstance(item, dict) else None
+        if not content:
+            logger.warning("Malformed result at index %s: %s", idx, item)
+            continue
+        valid_snippets.append(content)
+
+    if not valid_snippets:
+        message = f"No valid context snippets found for query: {query!r}"
+        logger.warning(message)
+        raise ValueError(message)
+
+    return "\n".join(valid_snippets[:top_k])

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -1,0 +1,41 @@
+import logging
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from app.rag import retrieve_context_snippets
+
+
+def test_retrieve_context_snippets_filters_invalid(caplog):
+    results = [
+        {"content": "valid1"},
+        {"no_content": "oops"},
+        {"content": ""},
+        {"content": "valid2"},
+    ]
+    with caplog.at_level(logging.WARNING):
+        context = retrieve_context_snippets("query", results=results)
+    assert context == "valid1\nvalid2"
+    assert "Malformed result at index 1" in caplog.text
+    assert "Malformed result at index 2" in caplog.text
+
+
+def test_retrieve_context_snippets_raises_with_only_invalid(caplog):
+    results = [
+        {"content": ""},
+        {"no_content": "oops"},
+    ]
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(ValueError):
+            retrieve_context_snippets("query", results=results)
+    assert "No valid context snippets found" in caplog.text
+
+
+def test_retrieve_context_snippets_raises_with_empty_results(caplog):
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(ValueError):
+            retrieve_context_snippets("query", results=[])
+    assert "No valid context snippets found" in caplog.text


### PR DESCRIPTION
## Summary
- validate RAG retrieval results by filtering out malformed entries and raising when none remain
- add optional injection for pre-fetched results and warnings for malformed data
- add unit tests covering malformed and empty retrieval results

## Testing
- `pytest tests/test_rag.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68956251877c8323bde5ab3b11a43e68