### PR TITLE
Package app and clean test imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,5 +76,6 @@ node_modules/
 *_demo.py
 check_*.py
 test_*.py
+!tests/test_rag.py
 demo_*.py
 setup_*.sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "mentor-app"
+version = "0.1.0"
+description = "Mentor app package"
+requires-python = ">=3.8"
+
+[tool.setuptools.packages.find]
+include = ["app*" ]

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -1,0 +1,8 @@
+import pytest
+
+from app.rag import retrieve_context_snippets
+
+
+def test_retrieve_context_snippets_returns_string():
+    result = retrieve_context_snippets("test")
+    assert isinstance(result, str)


### PR DESCRIPTION
## Summary
- Package the `app` module via `pyproject.toml` so it can be installed
- Add unit test for `retrieve_context_snippets` that imports `app.rag` without altering `sys.path`
- Adjust `.gitignore` to allow the new test file

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68955aa03d388323a40f3fc2b0c2a942