### PR TITLE
feat: add confirmation bypass to jira cli commands

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -10,6 +10,15 @@ from typing import Optional
 
 from .config import Config
 from . import capture, transcription, summarization, screen_record, knowledge_base
+from backend.integrations.jira_manager import JiraManager
+
+
+def _confirm(prompt: str, auto_confirm: bool) -> bool:
+    """Prompt the user to confirm an action unless auto-confirmed."""
+    if auto_confirm:
+        return True
+    response = input(f"{prompt} [y/N]: ").strip().lower()
+    return response in {"y", "yes"}
 
 
 def cmd_record_audio(args) -> None:
@@ -193,6 +202,36 @@ def cmd_answer(args) -> None:
         print("❌ No relevant context found in knowledge base")
 
 
+def cmd_jira_comment(args) -> None:
+    """Add comment to a JIRA issue."""
+    if not _confirm(f"Add comment to {args.issue}?", args.yes):
+        print("❌ Operation cancelled")
+        return
+
+    manager = JiraManager()
+    try:
+        manager.add_comment(args.issue, args.comment)
+        print(f"💬 Comment added to {args.issue}")
+    except Exception as e:
+        print(f"❌ Failed to add comment: {e}")
+
+
+def cmd_jira_transition(args) -> None:
+    """Transition a JIRA issue's status."""
+    if not _confirm(
+        f"Transition issue {args.issue} with {args.transition_id}?", args.yes
+    ):
+        print("❌ Operation cancelled")
+        return
+
+    manager = JiraManager()
+    try:
+        manager.transition_issue(args.issue, args.transition_id, args.comment)
+        print(f"🔀 Issue {args.issue} transitioned")
+    except Exception as e:
+        print(f"❌ Failed to transition issue: {e}")
+
+
 def create_parser() -> argparse.ArgumentParser:
     """Create command-line argument parser."""
     parser = argparse.ArgumentParser(
@@ -269,7 +308,32 @@ Examples:
     # Answer question command
     answer_parser = subparsers.add_parser('answer', help='Answer question using knowledge base')
     answer_parser.add_argument('question', help='Question to answer')
-    
+
+    # JIRA comment command
+    jira_comment = subparsers.add_parser(
+        'jira-comment', help='Add comment to a JIRA issue'
+    )
+    jira_comment.add_argument('issue', help='JIRA issue key')
+    jira_comment.add_argument('comment', help='Comment text')
+    jira_comment.add_argument(
+        '--yes',
+        action='store_true',
+        help='Bypass confirmation prompt and run non-interactively',
+    )
+
+    # JIRA transition command
+    jira_transition = subparsers.add_parser(
+        'jira-transition', help='Transition a JIRA issue'
+    )
+    jira_transition.add_argument('issue', help='JIRA issue key')
+    jira_transition.add_argument('transition_id', help='Transition ID')
+    jira_transition.add_argument('--comment', help='Optional comment to add')
+    jira_transition.add_argument(
+        '--yes',
+        action='store_true',
+        help='Bypass confirmation prompt and run non-interactively',
+    )
+
     return parser
 
 
@@ -283,7 +347,7 @@ def main() -> None:
         return
     
     # Commands that don't require API key
-    local_commands = {'screenshot', 'kb-stats'}
+    local_commands = {'screenshot', 'kb-stats', 'jira-comment', 'jira-transition'}
     
     # Validate environment
     try:
@@ -306,7 +370,9 @@ def main() -> None:
         'kb-ingest': cmd_kb_ingest,
         'kb-search': cmd_kb_search,
         'kb-stats': cmd_kb_stats,
-        'answer': cmd_answer
+        'answer': cmd_answer,
+        'jira-comment': cmd_jira_comment,
+        'jira-transition': cmd_jira_transition,
     }
     
     handler = command_handlers.get(args.command)


### PR DESCRIPTION
## Summary
- add `--yes` flag to `jira-comment` and `jira-transition` to skip manual confirmation
- ensure JIRA actions prompt by default via `_confirm` helper
- wire JIRA comment and transition into CLI command routing

## Testing
- `pytest`
- `python -m app.cli --help | head -n 40`
- `python -m app.cli jira-comment --help`
- `python -m app.cli jira-transition --help`
- `python -m app.cli jira-comment TEST-123 "Test comment" --yes`
- `python -m app.cli jira-transition TEST-123 1 --yes`


------
https://chatgpt.com/codex/tasks/task_e_689cbad451008323a0d753960b9d2fa8