### PR TITLE
Encode Jira auth header

### DIFF
--- a/app/integrations/jira_client.py
+++ b/app/integrations/jira_client.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-import os, requests
+import os, base64, requests
 from typing import Dict, Any
 
 class JiraClient:
@@ -10,7 +10,8 @@ class JiraClient:
         self.dry_run = True  # flip when approved
 
     def _headers(self):
-        return {'Authorization': f'Basic {self.user}:{self.token}', 'Content-Type': 'application/json'}
+        encoded = base64.b64encode(f"{self.user}:{self.token}".encode()).decode()
+        return {'Authorization': f'Basic {encoded}', 'Content-Type': 'application/json'}
 
     def create_issue(self, project_key: str, summary: str, description: str) -> Dict[str, Any]:
         if self.dry_run:

--- a/app/integrations/tests/test_jira_client.py
+++ b/app/integrations/tests/test_jira_client.py
@@ -1,0 +1,16 @@
+import base64
+from app.integrations.jira_client import JiraClient
+
+
+def test_headers_are_base64_encoded(monkeypatch):
+    user = 'user'
+    token = 'token'
+    monkeypatch.setenv('JIRA_USER', user)
+    monkeypatch.setenv('JIRA_TOKEN', token)
+
+    client = JiraClient()
+    headers = client._headers()
+
+    expected = base64.b64encode(f"{user}:{token}".encode()).decode()
+    assert headers['Authorization'] == f'Basic {expected}'
+    assert headers['Content-Type'] == 'application/json'


### PR DESCRIPTION
## Summary
- Properly encode Jira auth credentials using Base64
- Add unit test verifying correct header formation

## Testing
- `PYTHONPATH=. pytest app/integrations/tests/test_jira_client.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689cc188df7c832383c57b01099d7faf