### PR TITLE
Integrate diarization pipeline and meeting callbacks

### DIFF
--- a/tests/test_ai_assistant_integration.py
+++ b/tests/test_ai_assistant_integration.py
@@ -1,0 +1,60 @@
+import sys
+import asyncio
+from typing import Any
+from pathlib import Path
+import types
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+
+class DummyKB:
+    def add_document(self, *args, **kwargs):
+        pass
+
+    def search(self, *args, **kwargs):
+        return []
+
+
+class DummyTS:
+    def __init__(self):
+        pass
+
+
+class DummySumm:
+    def __init__(self):
+        pass
+
+
+sys.modules['app.knowledge_base'] = types.SimpleNamespace(KnowledgeBase=DummyKB)
+sys.modules['app.transcription'] = types.SimpleNamespace(TranscriptionService=DummyTS)
+sys.modules['app.summarization'] = types.SimpleNamespace(SummarizationService=DummySumm)
+
+from app.ai_assistant import AIAssistant
+
+
+async def _run_segments(assistant: AIAssistant):
+    await assistant.process_interview_speech("Can you tell me about your experience?", {})
+    await assistant.process_interview_speech("Sure, I have worked on many projects.", {})
+
+
+@pytest.mark.asyncio
+async def test_ai_assistant_records_segments(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    monkeypatch.setattr("app.ai_assistant.KnowledgeBase", DummyKB)
+    monkeypatch.setattr("app.ai_assistant.TranscriptionService", DummyTS)
+    monkeypatch.setattr("app.ai_assistant.SummarizationService", DummySumm)
+
+    assistant = AIAssistant()
+    assistant.mock_mode = True
+
+    await _run_segments(assistant)
+
+    session = assistant.memory.sessions.get("interview_session")
+    assert session is not None
+    assert len(session.conversations) == 2
+    first, second = session.conversations
+    assert first.context["is_interviewer"] is True
+    assert first.context["is_question"] is True
+    assert second.context["is_interviewer"] is False

--- a/tests/test_speaker_diarization.py
+++ b/tests/test_speaker_diarization.py
@@ -1,0 +1,32 @@
+import sys
+import numpy as np
+import wave
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from app.speaker_diarization import SpeakerDiarizer
+
+
+def _generate_test_wav(path: Path) -> Path:
+    sr = 16000
+    t = np.linspace(0, 0.5, int(sr * 0.5), endpoint=False)
+    s1 = 0.5 * np.sin(2 * np.pi * 220 * t)
+    s2 = 0.5 * np.sin(2 * np.pi * 330 * t)
+    silence = np.zeros(int(sr * 0.2))
+    audio = np.concatenate([s1, silence, s2])
+    pcm = (audio * 32767).astype("<i2")
+    with wave.open(str(path), "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(sr)
+        wf.writeframes(pcm.tobytes())
+    return path
+
+
+def test_diarizer_detects_multiple_speakers(tmp_path):
+    audio_path = _generate_test_wav(tmp_path / "two_speakers.wav")
+    diarizer = SpeakerDiarizer()
+    segments = diarizer.identify_speakers(str(audio_path))
+    assert len(segments) == 2
+    assert segments[0].speaker_id != segments[1].speaker_id
+    assert segments[0].end_time <= segments[1].start_time


### PR DESCRIPTION
## Summary
- integrate pyannote-based speaker diarization with a heuristic fallback
- trigger segment callbacks from InterviewFlowManager and hook them into AI assistant conversation memory
- add unit tests exercising diarization and assistant integration

## Testing
- `pytest tests/test_speaker_diarization.py tests/test_ai_assistant_integration.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689cc18fcb508323a3858b7d3aee45b0