### PR TITLE
Add meeting platform clients and caption routing

### DIFF
--- a/backend/meeting_clients/__init__.py
+++ b/backend/meeting_clients/__init__.py
@@ -1,0 +1,13 @@
+"""Meeting platform clients for capturing captions and audio."""
+
+from .base import BaseMeetingClient
+from .zoom import ZoomClient
+from .teams import TeamsClient
+from .google_meet import GoogleMeetClient
+
+__all__ = [
+    "BaseMeetingClient",
+    "ZoomClient",
+    "TeamsClient",
+    "GoogleMeetClient",
+]

--- a/backend/meeting_clients/base.py
+++ b/backend/meeting_clients/base.py
@@ -1,0 +1,61 @@
+"""Base client for meeting platforms.
+
+Each client is responsible for connecting to a meeting platform, capturing
+captions (and optionally audio), and forwarding those captions to both the
+meeting intelligence system and the realtime service running on port 8080.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Optional
+
+import requests
+
+from app.meeting_intelligence import meeting_intelligence
+
+log = logging.getLogger(__name__)
+
+
+class BaseMeetingClient:
+    """Reusable helper that forwards caption text to downstream services."""
+
+    def __init__(self, meeting_id: str, session_id: str, realtime_url: str = "http://localhost:8080"):
+        self.meeting_id = meeting_id
+        self.session_id = session_id
+        self.realtime_url = realtime_url.rstrip("/")
+
+    def process_caption(self, text: str, speaker: Optional[str] = None, timestamp: Optional[datetime] = None) -> None:
+        """Send caption text to meeting intelligence and realtime API."""
+        meeting_intelligence.process_caption(
+            meeting_id=self.meeting_id,
+            text=text,
+            speaker_id=speaker,
+            timestamp=timestamp,
+        )
+
+        payload = {"text": text}
+        if speaker:
+            payload["speaker"] = speaker
+        if timestamp:
+            payload["timestamp"] = timestamp.isoformat()
+
+        try:
+            requests.post(
+                f"{self.realtime_url}/api/sessions/{self.session_id}/captions",
+                json=payload,
+                timeout=5,
+            )
+        except Exception as exc:  # pragma: no cover - network failures best effort
+            log.warning("Failed to forward caption to realtime service: %s", exc)
+
+    # ------------------------------------------------------------------
+    # Methods expected from subclasses
+    # ------------------------------------------------------------------
+    def listen(self) -> None:  # pragma: no cover - placeholder for concrete clients
+        """Start listening for captions from the platform.
+
+        Subclasses should implement this method and call :meth:`process_caption`
+        whenever a new caption fragment is available.
+        """
+        raise NotImplementedError

--- a/backend/meeting_clients/google_meet.py
+++ b/backend/meeting_clients/google_meet.py
@@ -1,0 +1,23 @@
+"""Google Meet meeting client."""
+from __future__ import annotations
+
+import logging
+from typing import Iterable, Tuple, Optional
+
+from .base import BaseMeetingClient
+
+log = logging.getLogger(__name__)
+
+
+class GoogleMeetClient(BaseMeetingClient):
+    """Capture captions from Google Meet sessions.
+
+    This stub expects an iterable of ``(text, speaker)`` tuples. A full
+    implementation would connect to the Google Meet caption stream.
+    """
+
+    def listen(self, caption_source: Iterable[Tuple[str, Optional[str]]]) -> None:
+        for text, speaker in caption_source:
+            if text:
+                self.process_caption(text, speaker)
+                log.debug("Google Meet caption forwarded: %s", text)

--- a/backend/meeting_clients/teams.py
+++ b/backend/meeting_clients/teams.py
@@ -1,0 +1,23 @@
+"""Microsoft Teams meeting client."""
+from __future__ import annotations
+
+import logging
+from typing import Iterable, Tuple, Optional
+
+from .base import BaseMeetingClient
+
+log = logging.getLogger(__name__)
+
+
+class TeamsClient(BaseMeetingClient):
+    """Capture captions from Microsoft Teams meetings.
+
+    Real-world usage would rely on the Teams SDK or graph APIs. This lightweight
+    implementation consumes an iterable of caption tuples for demonstration.
+    """
+
+    def listen(self, caption_source: Iterable[Tuple[str, Optional[str]]]) -> None:
+        for text, speaker in caption_source:
+            if text:
+                self.process_caption(text, speaker)
+                log.debug("Teams caption forwarded: %s", text)

--- a/backend/meeting_clients/zoom.py
+++ b/backend/meeting_clients/zoom.py
@@ -1,0 +1,24 @@
+"""Zoom meeting client."""
+from __future__ import annotations
+
+import logging
+from typing import Iterable, Tuple, Optional
+
+from .base import BaseMeetingClient
+
+log = logging.getLogger(__name__)
+
+
+class ZoomClient(BaseMeetingClient):
+    """Capture captions from Zoom meetings.
+
+    The real integration would use the Zoom SDK or web socket hooks to obtain
+    live transcription. Here we accept an iterable of ``(text, speaker)`` tuples
+    for testing purposes.
+    """
+
+    def listen(self, caption_source: Iterable[Tuple[str, Optional[str]]]) -> None:
+        for text, speaker in caption_source:
+            if text:
+                self.process_caption(text, speaker)
+                log.debug("Zoom caption forwarded: %s", text)

--- a/browser_extension/overlay_client.js
+++ b/browser_extension/overlay_client.js
@@ -84,6 +84,20 @@
     es.onerror = () => setTimeout(() => connect(meetingId), 2000);
   }
 
+  // --- Caption forwarding
+  async function pushCaption(text, speaker = null) {
+    if (!state.meetingId) return;
+    try {
+      await fetch(`${state.backend}/api/sessions/${encodeURIComponent(state.meetingId)}/captions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text, speaker }),
+      });
+    } catch (e) {
+      console.warn('Failed to push caption', e);
+    }
+  }
+
   // --- Mic alignment (read-back auto-scroll)
   // Strategy: browser SpeechRecognition if available; fallback to noop.
   function startReadBackAlignment() {
@@ -133,6 +147,7 @@
 
   window.AIMOverlay = {
     connect,
+    pushCaption,
     setBackend: (b) => state.backend = b
   };
 


### PR DESCRIPTION
## Summary
- add BaseMeetingClient and platform stubs for Zoom, Teams, and Google Meet
- allow overlay to forward transcript captions to realtime service

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689cc5321f448323839d1654f171514b