### PR TITLE
Integrate GitHub/Jira managers with approval workflow

### DIFF
--- a/backend/approvals.py
+++ b/backend/approvals.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 import time, threading, queue
 from typing import Dict, Any, Optional
 
+from backend.integrations.github_manager import GitHubManager
+from backend.integrations.jira_manager import JiraManager
+from backend.pr_auto_reply import suggest_replies_and_patch
+
 class ApprovalItem:
     def __init__(self, action: str, payload: Dict[str, Any]):
         self.id = f"{action}-{int(time.time()*1000)}"
@@ -41,3 +45,51 @@ class ApprovalsQueue:
         return vars(item)
 
 approvals = ApprovalsQueue()
+
+# Expose integration managers for convenience across the backend
+github = GitHubManager(dry_run=True)
+jira = JiraManager(dry_run=True)
+
+def request_pr_auto_reply(owner: str, repo: str, pr_number: int, jira_issue: Optional[str] = None):
+    """Generate auto-reply suggestions for a PR and enqueue for approval.
+
+    If a Jira issue key is provided, a comment is added noting that suggestions
+    were generated for the related pull request.
+    """
+    pr = github.get_pr(owner, repo, pr_number)
+    files = github.get_pr_files(owner, repo, pr_number)
+    comments = github.get_pr_comments(owner, repo, pr_number)
+    suggestions = suggest_replies_and_patch(
+        pr.get("title", ""),
+        pr.get("body", "") or "",
+        files,
+        comments,
+    )
+
+    item = approvals.submit(
+        "github.pr_auto_reply",
+        {
+            "owner": owner,
+            "repo": repo,
+            "pr_number": pr_number,
+            "suggestions_json": suggestions["raw"],
+        },
+    )
+
+    if jira_issue:
+        jira.add_comment(jira_issue, f"Auto-reply suggestions queued for PR #{pr_number}")
+
+    return item
+
+def sync_jira_pr_status(owner: str, repo: str, pr_number: int, jira_issue: str):
+    """Update Jira issue based on the current status of a pull request."""
+    pr = github.get_pr(owner, repo, pr_number)
+    state = pr.get("state")
+    merged = bool(pr.get("merged_at"))
+
+    if merged:
+        jira.add_comment(jira_issue, f"PR #{pr_number} was merged")
+    else:
+        jira.add_comment(jira_issue, f"PR #{pr_number} state: {state}")
+
+    return {"state": state, "merged": merged}

--- a/docs/SERVER_INTEGRATION.md
+++ b/docs/SERVER_INTEGRATION.md
@@ -40,3 +40,35 @@ def jira_webhook():
     # handle event
     return '', 204
 ```
+
+## Configure GitHub and Jira managers
+
+Environment variables are used to talk to external services.  At minimum set:
+
+```bash
+export GITHUB_TOKEN="<personal access token>"
+export GITHUB_API="https://api.github.com"  # optional override
+
+export JIRA_BASE_URL="https://your-domain.atlassian.net"
+export JIRA_USER="bot@example.com"
+export JIRA_TOKEN="<jira api token>"
+```
+
+These values are read by `backend.integrations.github_manager.GitHubManager`
+and `backend.integrations.jira_manager.JiraManager`.
+
+## Approval flow
+
+Actions that touch GitHub or Jira go through `backend.approvals`.  Each action
+is queued and must be resolved via `POST /api/approvals/resolve` before the
+`approval_worker` executes it.
+
+Auto-reply suggestions for pull requests are created using
+`backend/pr_auto_reply.py`.  The helper
+`backend.approvals.request_pr_auto_reply()` fetches PR metadata, generates
+suggested comments, and enqueues the result.  When a PR is merged or its state
+changes, `backend.approvals.sync_jira_pr_status()` can be called to add a
+comment to the related Jira issue.
+
+This workflow provides auditable control over external integrations while still
+allowing helpful automation.


### PR DESCRIPTION
## Summary
- expose GitHub/Jira managers and helper functions in `backend/approvals`
- wire managers and PR helpers into `app/task_manager`
- document external config and approval flow for server integrations

## Testing
- `python -m py_compile app/task_manager.py backend/approvals.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689cca1d7308832393dc3657c6359f3d