### PR TITLE
Add caption streaming clients and demo

### DIFF
--- a/docs/CAPTION_STREAMING.md
+++ b/docs/CAPTION_STREAMING.md
@@ -1,0 +1,11 @@
+# Caption Streaming Demo
+
+This repository includes simple caption clients for Zoom, Microsoft Teams, and Google Meet. Each client reads caption lines from a text file and forwards them to the real‑time session manager.
+
+## Running the demo
+
+```bash
+python scripts/caption_flow_example.py
+```
+
+The script starts a session for each sample meeting and streams captions from files in `docs/sample_meetings/`. After streaming, the captured captions are printed to the console to verify end‑to‑end flow.

--- a/docs/sample_meetings/google_meet.txt
+++ b/docs/sample_meetings/google_meet.txt
@@ -1,0 +1,4 @@
+Teacher: Today we discuss distributed systems.
+Student: Sounds interesting!
+Teacher: What questions do you have?
+Student: How do we ensure consistency?

--- a/docs/sample_meetings/teams.txt
+++ b/docs/sample_meetings/teams.txt
@@ -1,0 +1,4 @@
+Moderator: Hello team, let's begin.
+Participant: I'm ready.
+Moderator: Can you give an update on the roadmap?
+Participant: We expect to finish next sprint.

--- a/docs/sample_meetings/zoom.txt
+++ b/docs/sample_meetings/zoom.txt
@@ -1,0 +1,4 @@
+Host: Welcome to the Zoom meeting.
+Guest: Thanks for having me today.
+Host: Could you explain your previous project?
+Guest: Certainly, it focused on real-time analytics.

--- a/scripts/caption_flow_example.py
+++ b/scripts/caption_flow_example.py
@@ -1,0 +1,39 @@
+"""Demo script for streaming captions from sample meetings.
+
+Each meeting platform client reads lines from a sample file and sends them
+through the RealtimeSessionManager.
+"""
+from __future__ import annotations
+
+import pprint
+
+import os
+import sys
+
+# Ensure project root is on the path when executed directly
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from app.capture import ZoomClient, TeamsClient, GoogleMeetClient
+from app.realtime import get_session_manager
+
+SAMPLES = {
+    ZoomClient: "docs/sample_meetings/zoom.txt",
+    TeamsClient: "docs/sample_meetings/teams.txt",
+    GoogleMeetClient: "docs/sample_meetings/google_meet.txt",
+}
+
+
+def run_demo():
+    manager = get_session_manager()
+    for client_cls, sample in SAMPLES.items():
+        session_id = manager.create_session({"user_name": client_cls.__name__})
+        client = client_cls(session_id=session_id, caption_file=sample)
+        client.stream_captions(delay=0.01)
+        session = manager.get_session(session_id)
+        print(f"\n{client_cls.__name__} captured:")
+        pprint.pp(session.caption_buffer if session else [])
+        manager.end_session(session_id)
+
+
+if __name__ == "__main__":
+    run_demo()


### PR DESCRIPTION
## Summary
- implement BaseCaptionClient with concrete Zoom, Teams, and Google Meet caption streaming clients
- add sample meeting transcripts, demo script, and usage docs

## Testing
- `python scripts/caption_flow_example.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689cca1a19608323aaeff177d34161a2