### PR TITLE
docs: reference production services and resume persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ The README has been aligned with the actual code so you can run it end-to-end to
 
 ## Architecture at a glance
 
-- Q&A + Resume API (port 8084): `simple_web.py`
+- Q&A + Resume API (port 8084): `production_backend.py`
     - POST /api/ask → generates an answer using `app/ai_assistant.py`
-    - POST/GET /api/resume → store/read resume text in memory
+    - POST/GET /api/resume → store/read resume text in SQLite (persistent)
     - GET /api/health → service health
-- Realtime sessions API (port 8080): `web_interface.py`
+- Realtime sessions API (port 8080): `production_realtime.py`
     - POST /api/sessions → create a session
     - GET /api/sessions/{id}/answers → recent answers for polling clients
     - GET /api/sessions/{id}/stream → Server-Sent Events (SSE) for realtime
@@ -40,10 +40,10 @@ cp .env.template .env
 
 ```bash
 # Terminal A – Q&A service (port 8084)
-python simple_web.py
+python production_backend.py
 
 # Terminal B – Realtime sessions (port 8080)
-python web_interface.py
+python production_realtime.py
 ```
 
 3) Test APIs
@@ -91,12 +91,12 @@ Edit `.env` (copied from `.env.template`):
 
 ## API summary
 
-- 8084 (simple_web):
+- 8084 (production_backend):
     - POST /api/ask { question, interview_mode? }
     - POST /api/resume { resume_text }
     - GET /api/resume
     - GET /api/health
-- 8080 (web_interface):
+- 8080 (production_realtime):
     - POST /api/sessions { user_level, meeting_type, user_name }
     - GET /api/sessions/{id}/answers
     - GET /api/sessions/{id}/stream (SSE)
@@ -107,7 +107,7 @@ Edit `.env` (copied from `.env.template`):
 ## Notes
 
 - Knowledge base persists to `data/chroma_db/`. Don’t commit that directory.
-- Resume storage is in-memory; re-upload after restarting the Q&A service.
+- Resume storage persists in a local SQLite database; your resume survives backend restarts.
 - Advanced features under `backend/` are imported defensively and the app runs without them.
 - `start_mentor_app.py` can start the Q&A service, but it references a bridge file not present. Prefer running the two services directly as shown above.
 
@@ -149,4 +149,4 @@ Stop the services when done:
 ./stop_services.sh
 ```
 
-Mock mode: If `OPENAI_API_KEY` isn’t set, the backend starts in a safe mock mode that returns placeholder answers (see `app/ai_assistant.py` and `simple_web.py` fallback). This lets you verify end-to-end flows without external credentials.
+Mock mode: If `OPENAI_API_KEY` isn’t set, the backend starts in a safe mock mode that returns placeholder answers (see `app/ai_assistant.py` and `production_backend.py` fallback). This lets you verify end-to-end flows without external credentials.


### PR DESCRIPTION
## Summary
- replace simple_web.py/web_interface.py with production_backend.py and production_realtime.py
- update Quick Start commands and API summary
- clarify resume storage uses SQLite for persistence

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app'; No module named 'requests'; No module named 'openai'; No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_689ce8020ab083238dd5b02eaf132dbc