### PR TITLE
Require explicit JWT secret for production backend

### DIFF
--- a/DEPLOYMENT_GUIDE.md
+++ b/DEPLOYMENT_GUIDE.md
@@ -49,10 +49,10 @@ Your **Production-Ready SaaS Backend** with:
    railway deploy
    ```
 
-3. **Set Environment Variables**
+3. **Set Environment Variables (JWT_SECRET is required, no default)**
    ```bash
    railway variables set OPENAI_API_KEY=sk-proj-your-key-here
-   railway variables set JWT_SECRET=super-secret-change-this
+   railway variables set JWT_SECRET=super-secret-change-this # required
    railway variables set FLASK_ENV=production
    ```
 
@@ -69,10 +69,10 @@ Your **Production-Ready SaaS Backend** with:
    heroku create ai-mentor-backend
    ```
 
-2. **Set Environment Variables**
+2. **Set Environment Variables (JWT_SECRET is required, no default)**
    ```bash
    heroku config:set OPENAI_API_KEY=sk-proj-your-key-here
-   heroku config:set JWT_SECRET=super-secret-change-this
+   heroku config:set JWT_SECRET=super-secret-change-this # required
    heroku config:set FLASK_ENV=production
    ```
 

--- a/PRODUCTION_ARCHITECTURE.md
+++ b/PRODUCTION_ARCHITECTURE.md
@@ -96,6 +96,7 @@ This is completely different from a developer tool!
 ### **Backend Environment:**
 ```bash
 # Production .env (on your server only)
+# JWT_SECRET must be set to a strong value; the backend exits if it is missing
 OPENAI_API_KEY=your_company_openai_key
 DATABASE_URL=your_database_connection
 JWT_SECRET=your_jwt_secret

--- a/PRODUCTION_READY_SUMMARY.md
+++ b/PRODUCTION_READY_SUMMARY.md
@@ -61,9 +61,9 @@ railway login
 railway create ai-mentor-backend
 railway deploy
 
-# Set environment variables
+# Set environment variables (JWT_SECRET is required, no default)
 railway variables set OPENAI_API_KEY=sk-proj-your-key-here
-railway variables set JWT_SECRET=super-secret-change-this-123
+railway variables set JWT_SECRET=super-secret-change-this-123 # required, no default
 
 # Get your domain
 railway domain
@@ -74,7 +74,7 @@ railway domain
 ```bash
 heroku create ai-mentor-backend
 heroku config:set OPENAI_API_KEY=sk-proj-your-key-here
-heroku config:set JWT_SECRET=super-secret-change-this-123
+heroku config:set JWT_SECRET=super-secret-change-this-123 # required, no default
 git push heroku main
 ```
 

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 # Procfile for Heroku deployment
+release: test -n "$JWT_SECRET" || (echo "JWT_SECRET environment variable not set" && exit 1)
 web: python production_backend.py

--- a/production_backend.py
+++ b/production_backend.py
@@ -3,6 +3,7 @@ Production Backend for AI Mentor - Q&A and Resume Service
 Port 8084 - Main service for browser extension and IDE plugins
 """
 import os
+import sys
 import sqlite3
 import json
 import jwt
@@ -27,6 +28,11 @@ except ImportError as e:
 # Load environment variables
 load_dotenv()
 
+JWT_SECRET = os.getenv("JWT_SECRET")
+if not JWT_SECRET:
+    print("Error: JWT_SECRET environment variable not set. Exiting.")
+    sys.exit(1)
+
 app = Flask(__name__)
 CORS(app, resources={
     r"/api/*": {
@@ -37,7 +43,7 @@ CORS(app, resources={
 })
 
 # Configuration
-app.config['SECRET_KEY'] = os.getenv('JWT_SECRET', 'your-secret-key-change-this')
+app.config['SECRET_KEY'] = JWT_SECRET
 app.config['DATABASE'] = os.getenv('DATABASE_PATH', 'production_mentor.db')
 
 # OpenAI Configuration

--- a/railway.toml
+++ b/railway.toml
@@ -1,4 +1,5 @@
 # Railway configuration for deployment
+# Ensure JWT_SECRET is set in Railway environment variables before deploying
 [build]
 builder = "NIXPACKS"
 


### PR DESCRIPTION
## Summary
- Fail fast if `JWT_SECRET` is missing and use it for Flask's secret key
- Add release-time env check and deployment notes for `JWT_SECRET`
- Document that deployments must provide `JWT_SECRET`

## Testing
- `pip install -r requirements.txt` *(fails: conflicting chromadb versions)*
- `PYTHONPATH=. JWT_SECRET=test pytest` *(fails: 3 failed, 14 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689ce804d4248323b3818dcfa4dde260