### PR TITLE
Remove in-memory resume storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Edit `.env` (copied from `.env.template`):
 ## Notes
 
 - Knowledge base persists to `data/chroma_db/`. Don’t commit that directory.
-- Resume storage is in-memory; re-upload after restarting the Q&A service.
+- Resumes persist in the `resumes` table of the SQLite database.
 - Advanced features under `backend/` are imported defensively and the app runs without them.
 - `start_mentor_app.py` can start the Q&A service, but it references a bridge file not present. Prefer running the two services directly as shown above.
 

--- a/production_backend.py
+++ b/production_backend.py
@@ -52,8 +52,6 @@ if AI_ASSISTANT_AVAILABLE:
         print(f"Failed to initialize AI Assistant: {e}")
         ai_assistant = None
 
-# In-memory storage for resume (for simplicity)
-resume_storage = {}
 
 def init_db():
     """Initialize the database."""


### PR DESCRIPTION
## Summary
- remove obsolete in-memory resume_storage variable
- document that resumes persist in the SQLite `resumes` table

## Testing
- `PYTHONPATH=. pytest -q` *(fails: async plugin missing; TypeError during module reload)*

------
https://chatgpt.com/codex/tasks/task_e_689ce8076fdc8323be13f36e5b136be8