### PR TITLE
feat: add optional screen recording

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The README has been aligned with the actual code so you can run it end-to-end to
     - GET /api/sessions/{id}/stream → Server-Sent Events (SSE) for realtime
     - POST /api/sessions/{id}/captions → push caption chunks with speaker hints
     - DELETE /api/sessions/{id} → end a session
+    - GET /api/sessions/{id}/recording?analyze=true → screen recording path or analysis
     - POST /api/meeting-events → legacy meeting event ingestion
 - Clients
     - Chrome extension in `browser_extension/` (calls 8084 for /api/ask and /api/resume, 8080 for meeting events)
@@ -34,6 +35,8 @@ source .venv/bin/activate
 pip install -r requirements.txt
 cp .env.template .env
 # Edit .env and set OPENAI_API_KEY
+# Optional: enable screen recording
+# SCREEN_RECORDING_ENABLED=true
 ```
 
 2) Start services in two terminals

--- a/app/config.py
+++ b/app/config.py
@@ -40,10 +40,12 @@ class Config:
     SAMPLE_RATE = int(os.getenv("SAMPLE_RATE", "44100"))
     CHANNELS = int(os.getenv("CHANNELS", "1"))
     CHUNK_SIZE = int(os.getenv("CHUNK_SIZE", "1024"))
-    
+
     # Screen recording settings
     SCREEN_FPS = int(os.getenv("SCREEN_FPS", "10"))
     SCREEN_QUALITY = int(os.getenv("SCREEN_QUALITY", "80"))
+    SCREEN_RECORDING_ENABLED = os.getenv("SCREEN_RECORDING_ENABLED", "false").lower() == "true"
+    SCREEN_RECORDING_DURATION = int(os.getenv("SCREEN_RECORDING_DURATION", "10"))  # seconds
     
     # Knowledge base settings
     CHROMA_PERSIST_DIR = os.getenv("CHROMA_PERSIST_DIR", "./data/chroma_db")


### PR DESCRIPTION
## Summary
- add optional screen recording when sessions start
- expose endpoint to fetch or analyze recorded screen
- document SCREEN_RECORDING_ENABLED configuration

## Testing
- `PYTHONPATH=. pytest` *(fails: TypeError: reload() argument must be a module)*

------
https://chatgpt.com/codex/tasks/task_e_689ce80d7ba8832382fc502f73c65a8f