### PR TITLE
feat: add oauth and speaker mapping

### DIFF
--- a/backend/diarization_service.py
+++ b/backend/diarization_service.py
@@ -30,14 +30,19 @@ class DiarizationService:
     For production, consider using WhisperX when it supports Python 3.13.
     """
 
-    def __init__(self, device: Optional[str] = None, hf_token: Optional[str] = None):
+    def __init__(self, device: Optional[str] = None, hf_token: Optional[str] = None, team_source: str = "github"):
         self.device = device or ("cuda" if TORCH_AVAILABLE and cast(Any, torch).cuda.is_available() else "cpu")
         self.hf_token = hf_token or os.getenv("HUGGINGFACE_TOKEN")
-        
+
         # For now, use a simple speaker assignment strategy
         # In production, this would be replaced with proper diarization
         self.known_speakers = ["interviewer", "candidate", "team_member"]
         self.current_speaker_index = 0
+
+        # Load potential team members from integrations so that diarized speaker
+        # IDs can be mapped to real users.  This keeps the mapping logic in one
+        # place and allows meeting_intelligence to ask for friendly names.
+        self.team_members = self._load_team_members(team_source)
 
         # Initialize whisper model if available
         if WHISPER_AVAILABLE:
@@ -51,6 +56,63 @@ class DiarizationService:
             log.warning("Whisper not available, using mock transcription")
             self.model = None
 
+    # ------------------------------------------------------------------
+    # Team member helpers
+    # ------------------------------------------------------------------
+    def _load_team_members(self, source: str) -> List[str]:
+        """Fetch team member names from GitHub or Jira integrations."""
+
+        members: List[str] = []
+        if source == "github":
+            try:
+                from backend.integrations.github_manager import GitHubManager
+
+                gh = GitHubManager()
+                owner = os.getenv("GITHUB_OWNER", "")
+                repo = os.getenv("GITHUB_REPO", "")
+                info = gh.get_repo_info(owner, repo)
+                owner_info = info.get("owner")
+                if isinstance(owner_info, dict):
+                    login = owner_info.get("login")
+                    if login:
+                        members.append(login)
+            except Exception as exc:  # pragma: no cover - network call
+                log.debug("Failed to load GitHub team members: %s", exc)
+        else:
+            try:
+                from backend.integrations.jira_manager import JiraManager
+
+                jira = JiraManager()
+                result = jira.search_issues("order by assignee", max_results=50)
+                for issue in result.get("issues", []):
+                    assignee = issue.get("fields", {}).get("assignee")
+                    if assignee and assignee.get("displayName"):
+                        members.append(assignee["displayName"])
+            except Exception as exc:  # pragma: no cover - network call
+                log.debug("Failed to load Jira team members: %s", exc)
+
+        return members
+
+    def resolve_speaker(self, speaker_label: str) -> Optional[str]:
+        """Map a diarized speaker label to a known team member."""
+
+        if not speaker_label:
+            return None
+
+        for member in self.team_members:
+            if member.lower() == speaker_label.lower():
+                return member
+
+        if speaker_label.startswith("speaker"):
+            try:
+                idx = int(speaker_label.replace("speaker", "")) - 1
+                if 0 <= idx < len(self.team_members):
+                    return self.team_members[idx]
+            except ValueError:
+                pass
+
+        return None
+
     def process_audio_file(self, audio_path: str) -> List[Dict[str, Any]]:
         """
         Processes an audio file, returns segments with speaker labels.
@@ -60,20 +122,22 @@ class DiarizationService:
         log.info(f"[DiarizationService] Processing {audio_path} on {self.device}...")
         
         if not self.model:
-            # Mock response for testing
+            # Mock response for testing.  Map the heuristic speaker labels to
+            # real team members when possible so downstream components can show
+            # friendly names.
             return [
                 {
-                    "speaker": "interviewer",
+                    "speaker": self.resolve_speaker("interviewer") or "interviewer",
                     "text": "Can you explain the architecture of your system?",
                     "start": 0.0,
-                    "end": 3.5
+                    "end": 3.5,
                 },
                 {
-                    "speaker": "candidate", 
+                    "speaker": self.resolve_speaker("candidate") or "candidate",
                     "text": "Sure, we use a microservices architecture with Docker containers...",
                     "start": 4.0,
-                    "end": 8.5
-                }
+                    "end": 8.5,
+                },
             ]
         
         try:
@@ -85,13 +149,16 @@ class DiarizationService:
             segments = []
             for i, segment in enumerate(cast(Any, result)["segments"]):
                 seg = cast(Dict[str, Any], segment)
-                speaker = self.known_speakers[i % len(self.known_speakers)]
-                segments.append({
-                    "speaker": speaker,
-                    "text": cast(str, seg.get("text", "")).strip(),
-                    "start": cast(Any, seg.get("start", 0.0)),
-                    "end": cast(Any, seg.get("end", 0.0))
-                })
+                speaker_label = self.known_speakers[i % len(self.known_speakers)]
+                speaker_name = self.resolve_speaker(speaker_label) or speaker_label
+                segments.append(
+                    {
+                        "speaker": speaker_name,
+                        "text": cast(str, seg.get("text", "")).strip(),
+                        "start": cast(Any, seg.get("start", 0.0)),
+                        "end": cast(Any, seg.get("end", 0.0)),
+                    }
+                )
             
             return segments
             
@@ -119,13 +186,15 @@ class DiarizationService:
         
         # Simple heuristics for speaker detection
         if any(keyword in text_lower for keyword in ["can you", "tell me", "explain", "how do", "what is"]):
-            return "interviewer"
+            label = "interviewer"
         elif any(keyword in text_lower for keyword in ["yes", "sure", "let me", "i have", "my experience"]):
-            return "candidate"
+            label = "candidate"
         else:
             # Default to alternating speakers
             self.current_speaker_index = (self.current_speaker_index + 1) % len(self.known_speakers)
-            return self.known_speakers[self.current_speaker_index]
+            label = self.known_speakers[self.current_speaker_index]
+
+        return self.resolve_speaker(label) or label
 
 
 if __name__ == "__main__":

--- a/backend/meeting_clients/google_meet.py
+++ b/backend/meeting_clients/google_meet.py
@@ -10,11 +10,21 @@ log = logging.getLogger(__name__)
 
 
 class GoogleMeetClient(BaseMeetingClient):
-    """Capture captions from Google Meet sessions.
+    """Capture captions from Google Meet sessions."""
 
-    This stub expects an iterable of ``(text, speaker)`` tuples. A full
-    implementation would connect to the Google Meet caption stream.
-    """
+    def authenticate(self, oauth_token: str) -> None:
+        super().authenticate(oauth_token)
+        log.debug("Authenticated Google Meet client")
+
+    def join_meeting(self, join_url: str) -> None:
+        super().join_meeting(join_url)
+        self.meeting_url = join_url
+
+    def start_recording(self) -> None:
+        super().start_recording()
+
+    def stop_recording(self) -> None:
+        super().stop_recording()
 
     def listen(self, caption_source: Iterable[Tuple[str, Optional[str]]]) -> None:
         for text, speaker in caption_source:

--- a/backend/meeting_clients/teams.py
+++ b/backend/meeting_clients/teams.py
@@ -10,11 +10,21 @@ log = logging.getLogger(__name__)
 
 
 class TeamsClient(BaseMeetingClient):
-    """Capture captions from Microsoft Teams meetings.
+    """Capture captions from Microsoft Teams meetings."""
 
-    Real-world usage would rely on the Teams SDK or graph APIs. This lightweight
-    implementation consumes an iterable of caption tuples for demonstration.
-    """
+    def authenticate(self, oauth_token: str) -> None:
+        super().authenticate(oauth_token)
+        log.debug("Authenticated Teams client")
+
+    def join_meeting(self, join_url: str) -> None:
+        super().join_meeting(join_url)
+        self.meeting_url = join_url
+
+    def start_recording(self) -> None:
+        super().start_recording()
+
+    def stop_recording(self) -> None:
+        super().stop_recording()
 
     def listen(self, caption_source: Iterable[Tuple[str, Optional[str]]]) -> None:
         for text, speaker in caption_source:

--- a/backend/meeting_clients/zoom.py
+++ b/backend/meeting_clients/zoom.py
@@ -10,13 +10,32 @@ log = logging.getLogger(__name__)
 
 
 class ZoomClient(BaseMeetingClient):
-    """Capture captions from Zoom meetings.
+    """Capture captions from Zoom meetings with lightweight OAuth handling."""
 
-    The real integration would use the Zoom SDK or web socket hooks to obtain
-    live transcription. Here we accept an iterable of ``(text, speaker)`` tuples
-    for testing purposes.
-    """
+    def authenticate(self, oauth_token: str) -> None:
+        """Store Zoom OAuth token using the base helper."""
 
+        super().authenticate(oauth_token)
+        log.debug("Authenticated Zoom client")
+
+    # ------------------------------------------------------------------
+    # Meeting control helpers
+    # ------------------------------------------------------------------
+    def join_meeting(self, join_url: str) -> None:
+        """Join a Zoom meeting via join URL."""
+
+        super().join_meeting(join_url)
+        self.meeting_url = join_url
+
+    def start_recording(self) -> None:
+        super().start_recording()
+
+    def stop_recording(self) -> None:
+        super().stop_recording()
+
+    # ------------------------------------------------------------------
+    # Caption handling
+    # ------------------------------------------------------------------
     def listen(self, caption_source: Iterable[Tuple[str, Optional[str]]]) -> None:
         for text, speaker in caption_source:
             if text:


### PR DESCRIPTION
## Summary
- extend base meeting client with OAuth hooks and join/record helpers
- add join/record features to Zoom, Teams, and Google Meet clients
- map diarization speaker IDs to team members via GitHub/Jira data

## Testing
- `pytest` *(fails: async plugin missing and module reload errors)*

------
https://chatgpt.com/codex/tasks/task_e_689cf2cfc6308323ad3c4a2d7395d6aa