### PR TITLE
Validate OpenAI key before doc agent init

### DIFF
--- a/backend/doc_agent.py
+++ b/backend/doc_agent.py
@@ -4,7 +4,11 @@ import os
 from typing import Dict, Any, List
 from openai import OpenAI
 
-client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+api_key = os.getenv("OPENAI_API_KEY")
+if not api_key:
+    raise RuntimeError("OPENAI_API_KEY environment variable is not set")
+
+client = OpenAI(api_key=api_key)
 
 ADR_SYSTEM = (
   "You generate engineering docs (ADR, runbook, changelog) from context. "

--- a/backend/server.py
+++ b/backend/server.py
@@ -414,6 +414,10 @@ def api_draft_adr():
     try:
         # Use explicit package path for editor/type checker compatibility
         from backend.doc_agent import draft_adr
+    except RuntimeError as e:
+        log.error(f"Doc agent initialization error: {e}")
+        return jsonify({"error": str(e)}), 500
+    try:
         d = request.get_json(force=True)
         md = draft_adr(d["title"], d.get("context",""), d.get("options",[]), d.get("decision",""), d.get("consequences",[]))
         return jsonify({"markdown": md})
@@ -427,6 +431,10 @@ def api_draft_runbook():
     """Generate operational runbook"""
     try:
         from backend.doc_agent import draft_runbook
+    except RuntimeError as e:
+        log.error(f"Doc agent initialization error: {e}")
+        return jsonify({"error": str(e)}), 500
+    try:
         d = request.get_json(force=True)
         md = draft_runbook(d["service"], d.get("incidents",[]), d.get("commands",[]), d.get("dashboards",[]))
         return jsonify({"markdown": md})
@@ -440,6 +448,10 @@ def api_draft_changelog():
     """Generate changelog from merged PRs"""
     try:
         from backend.doc_agent import draft_changelog
+    except RuntimeError as e:
+        log.error(f"Doc agent initialization error: {e}")
+        return jsonify({"error": str(e)}), 500
+    try:
         d = request.get_json(force=True)
         md = draft_changelog(d["repo"], d.get("merged_prs",[]))
         return jsonify({"markdown": md})


### PR DESCRIPTION
## Summary
- check `OPENAI_API_KEY` before creating OpenAI client
- handle doc agent initialization errors in doc routes

## Testing
- `PYTHONPATH=. pytest` *(fails: reload() argument must be a module)*

------
https://chatgpt.com/codex/tasks/task_e_689d07e1968c8323bcddd1a43229c57c