### PR TITLE
Add meeting notes summary and retrieval endpoint

### DIFF
--- a/backend/memory_service.py
+++ b/backend/memory_service.py
@@ -110,6 +110,23 @@ class MemoryService:
             # Fallback search
             return {"documents": [self.search_memory(category="meeting", query=query, limit=n_results)]}
 
+    def get_meeting_notes(self, meeting_id: str) -> List[Dict[str, Any]]:
+        """Retrieve stored meeting summaries for a specific meeting."""
+        cursor = self.doc_conn.cursor()
+        cursor.execute(
+            "SELECT summary, metadata, created_at FROM summaries WHERE meeting_id = ? ORDER BY created_at DESC",
+            (meeting_id,),
+        )
+        rows = cursor.fetchall()
+        notes = []
+        for summary, metadata, created_at in rows:
+            try:
+                meta = json.loads(metadata) if metadata else {}
+            except Exception:
+                meta = {}
+            notes.append({"summary": summary, "metadata": meta, "created_at": created_at})
+        return notes
+
     def add_task(self, task_id: str, description: str, metadata: Optional[Dict] = None):
         """Add a task to memory"""
         if self.client:


### PR DESCRIPTION
## Summary
- summarize meetings with action items and decisions and persist via MemoryService
- expose `/api/meetings/<id>/notes` endpoint to fetch stored meeting notes

## Testing
- `PYTHONPATH=. pytest` *(fails: reload() argument must be a module)*

------
https://chatgpt.com/codex/tasks/task_e_689d3b2b07508323a132beb5678522e4