### PR TITLE
Add knowledge base retrieval and integration tests

### DIFF
--- a/app/rag.py
+++ b/app/rag.py
@@ -1,5 +1,32 @@
+"""Retrieval utilities for the AI assistant.
+
+This module provides a thin wrapper around the :class:`KnowledgeBase`
+search functionality to fetch context snippets relevant to a query.  The
+returned snippets can then be supplied to the language model as additional
+context.
+"""
+
 from __future__ import annotations
+
 from typing import List
+
+from .knowledge_base import KnowledgeBase
+
+
 def retrieve_context_snippets(query: str, top_k: int = 5) -> str:
-    # TODO: plug your Chroma/pgvector retrieval here
-    return ""
+    """Retrieve relevant context snippets for a query.
+
+    Args:
+        query: Natural language query to search for.
+        top_k: Number of snippets to retrieve.
+
+    Returns:
+        A single string containing the concatenated text of the retrieved
+        snippets separated by blank lines. If no snippets are found, an
+        empty string is returned.
+    """
+
+    kb = KnowledgeBase()
+    results = kb.search(query, top_k=top_k)
+    snippets: List[str] = [r.get("content", "") for r in results if r.get("content")]
+    return "\n\n".join(snippets)


### PR DESCRIPTION
## Summary
- implement `retrieve_context_snippets` using `KnowledgeBase.search`
- add integration tests verifying snippet retrieval and session recording

## Testing
- `pytest tests/test_ai_assistant_integration.py -q`
- `PYTHONPATH=. pytest -q` *(fails: MissingSchema, jwt module, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689d41bddbe08323bcd60f1926352fc7