### PR TITLE
Persist and expose session recordings

### DIFF
--- a/app/meeting_intelligence.py
+++ b/app/meeting_intelligence.py
@@ -11,6 +11,7 @@ from datetime import datetime, timedelta
 from dataclasses import dataclass, asdict
 from app.config import Config
 from backend.diarization_service import DiarizationService
+from . import screen_record
 try:
     from app.summarization import SummarizationService
 except Exception as e:  # pragma: no cover - optional dependency
@@ -369,6 +370,8 @@ class MeetingIntelligence:
             except Exception as e:
                 logger.warning(f"Failed to store meeting summary: {e}")
 
+        recording_path = screen_record.get_recording_path(meeting_id)
+
         return {
             "meeting_id": meeting_id,
             "meeting_type": context.meeting_type,
@@ -379,6 +382,7 @@ class MeetingIntelligence:
             "duration": "unknown",  # Would calculate from start/end times
             "key_topics": list(set([topic for patterns in self.speaker_patterns.values() for topic in patterns["topics"]])),
             "summary": summary_text,
+            "recording_path": recording_path,
         }
     
     def _generate_ai_summary(self, context: MeetingContext) -> str:

--- a/tests/test_recording_persistence.py
+++ b/tests/test_recording_persistence.py
@@ -1,0 +1,86 @@
+import sys
+import json
+from pathlib import Path
+import importlib
+
+
+def setup_module(module):
+    sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+
+def test_get_recording_path(tmp_path, monkeypatch):
+    from app import screen_record
+    monkeypatch.setattr(screen_record.Config, "RECORDINGS_DIR", tmp_path)
+    metadata = {
+        "session_id": "s1",
+        "video_path": str(tmp_path / "s1.mp4"),
+        "recorded_at": "now",
+    }
+    (tmp_path / "s1_metadata.json").write_text(json.dumps(metadata))
+    assert screen_record.get_recording_path("s1") == str(tmp_path / "s1.mp4")
+
+
+def test_recording_endpoint_returns_path(tmp_path, monkeypatch):
+    monkeypatch.setenv("JWT_SECRET", "secret")
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    monkeypatch.setenv("REALTIME_DATABASE_PATH", str(tmp_path / "db.sqlite"))
+
+    if "production_realtime" in sys.modules:
+        del sys.modules["production_realtime"]
+    import production_realtime
+    importlib.reload(production_realtime)
+
+    production_realtime.app.config["TESTING"] = True
+
+    from app import screen_record as sr
+    monkeypatch.setattr(sr.Config, "RECORDINGS_DIR", tmp_path)
+    monkeypatch.setattr(production_realtime.screen_record.Config, "RECORDINGS_DIR", tmp_path)
+
+    metadata = {
+        "session_id": "sess1",
+        "video_path": str(tmp_path / "sess1.mp4"),
+        "recorded_at": "now",
+    }
+    (tmp_path / "sess1_metadata.json").write_text(json.dumps(metadata))
+
+    production_realtime.session_recordings.clear()
+    monkeypatch.setattr(production_realtime, "verify_token", lambda token: {"user_id": 1})
+
+    class DummyCursor:
+        def fetchone(self):
+            return {"id": "sess1"}
+
+    class DummyDB:
+        def execute(self, *args, **kwargs):
+            return DummyCursor()
+
+    monkeypatch.setattr(production_realtime, "get_db", lambda: DummyDB())
+
+    client = production_realtime.app.test_client()
+    resp = client.get(
+        "/api/sessions/sess1/recording",
+        headers={"Authorization": "Bearer t"},
+    )
+    data = resp.get_json()
+    assert resp.status_code == 200
+    assert data["video_path"] == str(tmp_path / "sess1.mp4")
+
+
+def test_meeting_summary_links_recording(tmp_path, monkeypatch):
+    from app.meeting_intelligence import meeting_intelligence, MeetingContext
+    from app import screen_record
+
+    ctx = MeetingContext(
+        meeting_id="sess2",
+        meeting_type="standup",
+        participants=[],
+        action_items=[],
+        decisions=[],
+        agenda_items=[],
+    )
+    meeting_intelligence.active_meetings["sess2"] = ctx
+
+    monkeypatch.setattr(screen_record, "get_recording_path", lambda _: str(tmp_path / "sess2.mp4"))
+
+    summary = meeting_intelligence.get_meeting_summary("sess2")
+    assert summary["recording_path"] == str(tmp_path / "sess2.mp4")


### PR DESCRIPTION
## Summary
- Persist screen recordings with session metadata for later retrieval
- Update realtime service to store and expose recordings, including download and analysis
- Link meeting summaries to stored recordings
- Add tests verifying recording path persistence and API retrieval

## Testing
- `pytest tests/test_recording_persistence.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app'; ModuleNotFoundError: No module named 'requests'; ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_689d41c4700c8323a240e422108987a2