### PR TITLE
Add metadata check in AI assistant integration tests

### DIFF
--- a/tests/test_ai_assistant_integration.py
+++ b/tests/test_ai_assistant_integration.py
@@ -103,3 +103,22 @@ def test_retrieve_context_snippets_empty(monkeypatch):
 
     monkeypatch.setattr("app.rag.KnowledgeBase", EmptyKB)
     assert retrieve_context_snippets("unknown") == ""
+
+
+def test_search_returns_metadata():
+    class MetaKB:
+        def search(self, query: str, top_k: int = 5, filter_metadata: Any | None = None):
+            return [
+                {"content": "Remember this note", "metadata": {"type": "note"}}
+            ]
+
+        def get_collection_info(self):
+            return {"document_count": 1, "last_type": "note"}
+
+    assistant = AIAssistant()
+    assistant.memory.kb = MetaKB()
+
+    results = assistant.memory.search_conversation_history("note")
+    assert results[0]["metadata"]["type"] == "note"
+    stats = assistant.memory.kb.get_collection_info()
+    assert stats["last_type"] == "note"


### PR DESCRIPTION
## Summary
- extend AI assistant integration tests to assert knowledge base search returns metadata and exposes stats

## Testing
- `pytest tests/test_ai_assistant_integration.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app', 'requests', 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_689d479097248323a557b87f87a2a448