### PR TITLE
Ensure recordings directory exists before screen capture

### DIFF
--- a/app/screen_record.py
+++ b/app/screen_record.py
@@ -352,10 +352,11 @@ def record_screen(session_id: str, duration: Optional[int] = None) -> str:
     
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     video_path = os.path.join(Config.RECORDINGS_DIR, f"{session_id}_{timestamp}_screen.mp4")
-    
+
     recorder = ScreenRecorder()
-    
+
     try:
+        os.makedirs(Config.RECORDINGS_DIR, exist_ok=True)
         recorder.start_recording(video_path)
         
         if duration:


### PR DESCRIPTION
## Summary
- Safeguard screen recording by creating the recordings directory before starting capture

## Testing
- `PYTHONPATH=. pytest -q` *(fails: missing JIRA base URL and flask_cors, module reload issues)*

------
https://chatgpt.com/codex/tasks/task_e_689d47ab38c88323b61c989307198fa9