### PR TITLE
Implement VAD diarization and configurable question detection

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -49,6 +49,11 @@ class Config:
     AUDIO_CHUNK_DURATION = int(os.getenv("AUDIO_CHUNK_DURATION", "5"))  # seconds per chunk
     SCREEN_ANALYSIS_INTERVAL = int(os.getenv("SCREEN_ANALYSIS_INTERVAL", "30"))  # seconds
     AI_ASSISTANCE_THRESHOLD = float(os.getenv("AI_ASSISTANCE_THRESHOLD", "0.7"))  # confidence threshold
+
+    # Question boundary detector settings
+    QUESTION_SILENCE_MS_MIN = int(os.getenv("QUESTION_SILENCE_MS_MIN", "700"))
+    QUESTION_SILENCE_MS_MAX = int(os.getenv("QUESTION_SILENCE_MS_MAX", "900"))
+    QUESTION_MAX_LEN_CHARS = int(os.getenv("QUESTION_MAX_LEN_CHARS", "2000"))
     
     # Audio recording settings
     SAMPLE_RATE = int(os.getenv("SAMPLE_RATE", "44100"))

--- a/app/question_detector.py
+++ b/app/question_detector.py
@@ -2,15 +2,22 @@ from __future__ import annotations
 from typing import Optional
 import time
 
+from app.config import Config
+
 class QuestionBoundaryDetector:
-    """Simple end-of-question detector using timestamps/silence.
-    In production, combine VAD + punctuation-aware heuristics.
-    """
-    def __init__(self, min_gap_ms: int = 600, max_len_chars: int = 2000):
+    """End-of-question detector using silence and punctuation."""
+
+    def __init__(
+        self,
+        min_gap_ms: int = Config.QUESTION_SILENCE_MS_MIN,
+        max_gap_ms: int = Config.QUESTION_SILENCE_MS_MAX,
+        max_len_chars: int = Config.QUESTION_MAX_LEN_CHARS,
+    ):
         self.min_gap_ms = min_gap_ms
+        self.max_gap_ms = max_gap_ms
         self.max_len_chars = max_len_chars
         self._last_token_time = None
-        self._buffer = []
+        self._buffer: list[str] = []
 
     def add_token(self, text: str) -> Optional[str]:
         now = int(time.time() * 1000)
@@ -21,14 +28,20 @@ class QuestionBoundaryDetector:
 
         self._buffer.append(text)
 
-        # Heuristic: gap long enough OR question punctuation at end
+        # Heuristic: gap within threshold or ending punctuation
         joined = ''.join(self._buffer)
         if len(joined) >= self.max_len_chars:
             out = joined
             self._buffer = []
             return out
 
-        if text.strip().endswith( ('?', '？') ) or gap >= self.min_gap_ms:
+        stripped = text.strip()
+        if stripped.endswith( ('?', '？', '.', '!', '！', '。') ):
+            out = joined.strip()
+            self._buffer = []
+            return out
+
+        if self.min_gap_ms <= gap <= self.max_gap_ms or gap > self.max_gap_ms:
             out = joined.strip()
             self._buffer = []
             return out

--- a/tests/test_diarization_service.py
+++ b/tests/test_diarization_service.py
@@ -1,0 +1,32 @@
+import sys
+import numpy as np
+import wave
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from backend.diarization_service import DiarizationService
+
+
+def _generate_test_wav(path: Path) -> Path:
+    sr = 16000
+    t = np.linspace(0, 0.5, int(sr * 0.5), endpoint=False)
+    s1 = 0.5 * np.sin(2 * np.pi * 220 * t)
+    s2 = 0.5 * np.sin(2 * np.pi * 330 * t)
+    silence = np.zeros(int(sr * 0.2))
+    audio = np.concatenate([s1, silence, s2])
+    pcm = (audio * 32767).astype("<i2")
+    with wave.open(str(path), "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(sr)
+        wf.writeframes(pcm.tobytes())
+    return path
+
+
+def test_vad_diarization_assigns_speakers(tmp_path):
+    audio_path = _generate_test_wav(tmp_path / "vad.wav")
+    service = DiarizationService()
+    segments = service.process_audio_file(str(audio_path))
+    assert len(segments) == 2
+    assert segments[0]["speaker"] != segments[1]["speaker"]
+    assert segments[0]["end"] <= segments[1]["start"]

--- a/tests/test_question_detector.py
+++ b/tests/test_question_detector.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import app.question_detector as qd
+from app.config import Config
+
+
+class FakeTime:
+    def __init__(self):
+        self.t = 0.0
+
+    def advance(self, ms: int) -> None:
+        self.t += ms / 1000.0
+
+    def time(self) -> float:
+        return self.t
+
+
+def test_punctuation_boundary():
+    det = qd.QuestionBoundaryDetector()
+    out = det.add_token("How are you?")
+    assert out == "How are you?"
+
+
+def test_silence_boundary(monkeypatch):
+    fake = FakeTime()
+    monkeypatch.setattr(qd.time, "time", fake.time)
+    det = qd.QuestionBoundaryDetector()
+    assert det.add_token("Hello") is None
+    fake.advance(Config.QUESTION_SILENCE_MS_MIN + 50)
+    out = det.add_token(" there")
+    assert out == "Hello there"


### PR DESCRIPTION
## Summary
- replace heuristic diarization with simple VAD + Whisper tiny ASR pipeline
- add silence and punctuation based question boundary detection with Config thresholds
- add unit tests for diarization speaker attribution and question segmentation

## Testing
- `pytest tests/test_diarization_service.py tests/test_question_detector.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689fc9e80ef88323b3017562519f61ca