### PR TITLE
Add system audio capture backends

### DIFF
--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -1,0 +1,24 @@
+# Deployment Guide
+
+## Platform Requirements for System Audio Capture
+
+The meeting capture utilities rely on `ffmpeg` and platform specific audio backends.
+Ensure the following requirements are met on the target system:
+
+### macOS
+- macOS 13 or later with ScreenCaptureKit support
+- `ffmpeg` installed (`brew install ffmpeg`)
+- Screen Recording permission granted to the application
+
+### Windows
+- Windows 10 or later
+- `ffmpeg` installed and available on `PATH`
+- WASAPI loopback capture is used; no additional drivers are required
+
+### Linux
+- A PulseAudio or PipeWire based system
+- `ffmpeg` installed and available on `PATH`
+- The user must have permission to access the audio server
+
+These dependencies are only required when enabling system audio recording via
+`capture_meeting(record_system_audio=True)`.


### PR DESCRIPTION
## Summary
- add ffmpeg-powered system audio recorders for macOS (ScreenCaptureKit), Windows (WASAPI) and Linux (PulseAudio/PipeWire)
- allow `capture_meeting` to optionally capture loopback/system audio
- document platform requirements for audio capture in `docs/DEPLOYMENT_GUIDE.md`

## Testing
- `PYTHONPATH=. pytest` *(fails: requests.exceptions.MissingSchema, TypeError: object() takes no arguments)*

------
https://chatgpt.com/codex/tasks/task_e_689fc9eda99c83238cf43062bf3cd1b3