### PR TITLE
feat: expand rag context control

### DIFF
--- a/app/rag.py
+++ b/app/rag.py
@@ -8,25 +8,72 @@ context.
 
 from __future__ import annotations
 
-from typing import List
+from typing import List, Optional
+
+import tiktoken
 
 from .knowledge_base import KnowledgeBase
 
 
-def retrieve_context_snippets(query: str, top_k: int = 5) -> str:
+def retrieve_context_snippets(
+    query: str,
+    top_k: int = 5,
+    *,
+    max_tokens: int = 1000,
+    source_filters: Optional[List[str]] = None,
+    priority_order: Optional[List[str]] = None,
+) -> str:
     """Retrieve relevant context snippets for a query.
 
     Args:
         query: Natural language query to search for.
-        top_k: Number of snippets to retrieve.
+        top_k: Number of snippets to retrieve from the knowledge base.
+        max_tokens: Maximum number of tokens allowed in the returned context.
+        source_filters: Optional list of metadata sources to filter results by.
+        priority_order: Optional list specifying the order of sources by
+            priority. Sources appearing earlier in this list will be preferred
+            when assembling the final context string.
 
     Returns:
         A single string containing the concatenated text of the retrieved
-        snippets separated by blank lines. If no snippets are found, an
-        empty string is returned.
+        snippets separated by blank lines. The total token count will not
+        exceed ``max_tokens``. If no snippets are found, an empty string is
+        returned.
     """
 
     kb = KnowledgeBase()
-    results = kb.search(query, top_k=top_k)
-    snippets: List[str] = [r.get("content", "") for r in results if r.get("content")]
+
+    filter_metadata = None
+    if source_filters:
+        filter_metadata = {"source": {"$in": source_filters}}
+
+    results = kb.search(query, top_k=top_k, filter_metadata=filter_metadata)
+
+    # Apply priority ordering if provided
+    if priority_order:
+        order_map = {source: idx for idx, source in enumerate(priority_order)}
+        results.sort(
+            key=lambda r: order_map.get(r.get("metadata", {}).get("source"), len(order_map))
+        )
+
+    # Enforce strict token budget when assembling snippets
+    encoding = tiktoken.get_encoding("cl100k_base")
+    separator_tokens = len(encoding.encode("\n\n"))
+    remaining = max_tokens
+    snippets: List[str] = []
+
+    for result in results:
+        content = result.get("content", "")
+        if not content:
+            continue
+
+        tokens = len(encoding.encode(content))
+        needed = tokens if not snippets else tokens + separator_tokens
+
+        if needed > remaining:
+            break
+
+        snippets.append(content)
+        remaining -= needed
+
     return "\n\n".join(snippets)


### PR DESCRIPTION
## Summary
- allow RAG retrieval to limit tokens, filter by source and prioritize sources
- apply recency-based decay when searching the knowledge base
- add tests for recency ordering and token budget

## Testing
- `pytest tests/test_ai_assistant_integration.py::test_search_recency_decay -q`
- `pytest tests/test_ai_assistant_integration.py::test_retrieve_context_snippets_respects_priority_and_token_limit -q`
- `pytest tests/test_ai_assistant_integration.py -q`
- `pytest -q` *(fails: No module named 'chromadb')*


------
https://chatgpt.com/codex/tasks/task_e_689fc9f3f2708323ba2a22f2d1b45e0f