### PR TITLE
Verify GitHub webhook signatures and queue CI patch PRs

### DIFF
--- a/tests/test_ci_watcher_patch.py
+++ b/tests/test_ci_watcher_patch.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from backend.watchers import ci_watcher
+
+
+def test_ci_watcher_enqueues_patch(monkeypatch):
+    sample_patch = """--- a/foo.txt\n+++ b/foo.txt\n@@\n-old\n+new\n"""
+    submitted = []
+
+    class DummyApprovals:
+        def submit(self, action, payload):
+            submitted.append((action, payload))
+            class Item:
+                id = '1'
+            return Item()
+
+    monkeypatch.setattr(ci_watcher, 'get_approvals', lambda: DummyApprovals())
+
+    class DummyMonitor:
+        def monitor_repository(self, repo, branch):
+            return {'recent_failures': [{'analysis': {'proposed_patch': sample_patch}}]}
+
+    monkeypatch.setattr(ci_watcher, 'BuildMonitor', lambda: DummyMonitor())
+
+    payload = {
+        'action': 'completed',
+        'check_suite': {
+            'conclusion': 'failure',
+            'head_branch': 'main',
+            'id': 1,
+            'head_sha': 'abc',
+            'pull_requests': [{'number': 1, 'title': 't'}],
+        },
+        'repository': {'full_name': 'owner/repo'},
+    }
+
+    ci_watcher.handle_check_suite(payload)
+
+    actions = [a for a, _ in submitted]
+    assert 'github.apply_patch' in actions
+    patch_payload = next(p for a, p in submitted if a == 'github.apply_patch')
+    expected = ci_watcher.compute_minimal_patch(sample_patch)
+    assert patch_payload['patch_content'].strip() == expected.strip()

--- a/tests/test_webhook_signatures.py
+++ b/tests/test_webhook_signatures.py
@@ -1,0 +1,81 @@
+import os
+import sys
+import types
+from pathlib import Path
+
+# Ensure repo root on sys.path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+# Stub chromadb before importing server to avoid heavy dependency
+dummy_collection = type('DummyCollection', (), {'add': lambda *a, **k: None, 'query': lambda *a, **k: {}})
+class DummyClient:
+    def get_or_create_collection(self, name):
+        return dummy_collection()
+chromadb_stub = types.SimpleNamespace(Client=lambda *a, **k: DummyClient(), config=types.SimpleNamespace(Settings=lambda *a, **k: None))
+sys.modules.setdefault('chromadb', chromadb_stub)
+sys.modules.setdefault('chromadb.config', chromadb_stub.config)
+
+# Stub openai client
+class DummyOpenAI:
+    def __init__(self, *a, **k):
+        pass
+    class chat:
+        class completions:
+            @staticmethod
+            def create(*a, **k):
+                class R:
+                    choices = [type('C', (), {'message': type('M', (), {'content': '{}'})})]
+                return R()
+openai_stub = types.SimpleNamespace(OpenAI=DummyOpenAI)
+sys.modules.setdefault('openai', openai_stub)
+# Stub dotenv
+sys.modules.setdefault('dotenv', types.SimpleNamespace(load_dotenv=lambda *a, **k: None))
+# Stub stripe
+class DummyStripe:
+    api_key = ""
+    class Price:
+        @staticmethod
+        def create(**kwargs):
+            return {}
+    class Subscription:
+        @staticmethod
+        def create(**kwargs):
+            return {"status": "active"}
+    class InvoiceItem:
+        @staticmethod
+        def create(**kwargs):
+            return {}
+    class Invoice:
+        @staticmethod
+        def create(**kwargs):
+            return {}
+    class Webhook:
+        @staticmethod
+        def construct_event(payload, sig, secret):
+            return {}
+sys.modules.setdefault('stripe', DummyStripe)
+
+# Set secret before importing server
+os.environ['GITHUB_WEBHOOK_SECRET'] = 'test-secret'
+
+from backend import server
+
+
+def test_github_webhook_rejects_bad_signature():
+    client = server.app.test_client()
+    res = client.post('/webhook/github', data=b'{}', headers={
+        'X-Hub-Signature-256': 'sha256=bad',
+        'X-GitHub-Event': 'push',
+        'Content-Type': 'application/json'
+    })
+    assert res.status_code == 401
+
+
+def test_github_pr_webhook_rejects_bad_signature():
+    client = server.app.test_client()
+    res = client.post('/webhook/github/pr', data=b'{}', headers={
+        'X-Hub-Signature-256': 'sha256=bad',
+        'X-GitHub-Event': 'pull_request',
+        'Content-Type': 'application/json'
+    })
+    assert res.status_code == 401


### PR DESCRIPTION
## Summary
- validate `X-Hub-Signature-256` on GitHub and PR webhook endpoints
- derive minimal diffs from CI failures and enqueue apply-patch PRs via approvals queue
- add tests for webhook signature rejection and CI watcher patch requests

## Testing
- `pytest tests/test_webhook_signatures.py tests/test_ci_watcher_patch.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app', ModuleNotFoundError: No module named 'jwt', ModuleNotFoundError: No module named 'numpy', TypeError: object() takes no arguments)*

------
https://chatgpt.com/codex/tasks/task_e_689fc9f6688883238e850500907e92f7