### PR TITLE
Add health checks, token caps, and audit logging

### DIFF
--- a/backend/audit.py
+++ b/backend/audit.py
@@ -1,13 +1,28 @@
 from __future__ import annotations
 import json, os, time, threading
 from typing import Dict, Any
+from flask import request
 
 _AUDIT_PATH = os.getenv("AUDIT_LOG_PATH", "./logs/audit.log")
 os.makedirs(os.path.dirname(_AUDIT_PATH), exist_ok=True)
 _lock = threading.Lock()
 
 def audit(event: str, data: Dict[str, Any]):
-    rec = {"ts": time.time(), "event": event, "data": data}
+    """Record a structured audit log entry."""
+    try:
+        actor = request.headers.get("X-User-Key") or request.remote_addr or "anon"
+        path = request.path
+    except Exception:
+        actor = None
+        path = None
+
+    rec = {
+        "ts": time.time(),
+        "event": event,
+        "actor": actor,
+        "path": path,
+        "data": data,
+    }
     line = json.dumps(rec, ensure_ascii=False)
     with _lock:
         with open(_AUDIT_PATH, "a", encoding="utf-8") as f:


### PR DESCRIPTION
## Summary
- extend health endpoint to verify vector DB connection, approvals backlog, and webhook secrets
- enforce per-user token caps in middleware and improve rate limiting
- add structured audit logging and record write operations across endpoints

## Testing
- `PYTHONPATH=. pytest` *(fails: Invalid URL '/rest/api/3/search'; TypeError: object() takes no arguments)*


------
https://chatgpt.com/codex/tasks/task_e_689fc9f8b0d48323ba9983460ef38281