### PR TITLE
Add health check endpoint and rate-limited meeting events

### DIFF
--- a/backend/app_factory.py
+++ b/backend/app_factory.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+from flask import Flask, jsonify, request
+from .healthz import bp as healthz_bp
+from .middleware import rate_limit, record_cost
+
+
+def create_app():
+    """Application factory for tests and development."""
+    app = Flask(__name__)
+    # Register health check blueprint
+    app.register_blueprint(healthz_bp)
+
+    @app.post("/api/meeting-events")
+    @rate_limit("meeting")
+    def meeting_events():
+        payload = request.get_json(silent=True) or {}
+        # track token usage; default to 0 if not provided
+        tokens = int(payload.get("tokens", 0)) if isinstance(payload.get("tokens"), int) else 0
+        record_cost(tokens=tokens)
+        return jsonify({"ok": True})
+
+    return app

--- a/backend/healthz.py
+++ b/backend/healthz.py
@@ -8,10 +8,15 @@ bp = Blueprint("healthz", __name__)
 @bp.get("/healthz/full")
 def full():
     checks = {}
+    # Ensure OpenAI key is configured
     checks["OPENAI_API_KEY"] = bool(os.getenv("OPENAI_API_KEY"))
-    db_path = os.getenv("MEMORY_DB_PATH", "./memory_db")
-    checks["VECTOR_DB_PATH_EXISTS"] = os.path.exists(db_path) or os.path.exists("./data/chroma_db")
+    # Verify vector database path exists (default ./data/chroma_db)
+    vector_path = os.getenv("VECTOR_DB_PATH", "./data/chroma_db")
+    checks["VECTOR_DB_PATH_EXISTS"] = os.path.exists(vector_path)
+    # Webhook secrets
     checks["GITHUB_WEBHOOK_SECRET"] = bool(os.getenv("GITHUB_WEBHOOK_SECRET"))
+    checks["JIRA_WEBHOOK_SECRET"] = bool(os.getenv("JIRA_WEBHOOK_SECRET"))
+    # Rate limit bucket status (number of active buckets)
     checks["RATE_BUCKETS"] = len(BUCKETS.buckets)
     healthy = all(v if isinstance(v, bool) else True for v in checks.values())
     return jsonify({"ok": healthy, "checks": checks})

--- a/tests/test_healthz_full.py
+++ b/tests/test_healthz_full.py
@@ -1,0 +1,23 @@
+import os
+import sys
+from pathlib import Path
+
+# Ensure repo root on path for local imports
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from backend.app_factory import create_app
+
+
+def test_healthz_full(tmp_path):
+    os.environ['OPENAI_API_KEY'] = 'test'
+    os.environ['GITHUB_WEBHOOK_SECRET'] = 'gh'
+    os.environ['JIRA_WEBHOOK_SECRET'] = 'jira'
+    app = create_app()
+    client = app.test_client()
+    res = client.get('/healthz/full')
+    assert res.status_code == 200
+    data = res.get_json()
+    assert data['checks']['OPENAI_API_KEY'] is True
+    assert data['checks']['VECTOR_DB_PATH_EXISTS'] is True
+    assert data['checks']['GITHUB_WEBHOOK_SECRET'] is True
+    assert data['checks']['JIRA_WEBHOOK_SECRET'] is True

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,0 +1,22 @@
+import sys
+from pathlib import Path
+
+# Ensure repo root is on path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from backend.app_factory import create_app
+from backend import middleware
+
+
+def test_meeting_events_rate_limiting():
+    app = create_app()
+    client = app.test_client()
+    # lower rate limit for test
+    middleware.BUCKETS.rates['MEETING_EVENTS_PER_MIN'] = 2
+    # first three requests pass (initial bucket creation grants full tokens)
+    assert client.post('/api/meeting-events', json={}).status_code == 200
+    assert client.post('/api/meeting-events', json={}).status_code == 200
+    assert client.post('/api/meeting-events', json={}).status_code == 200
+    # fourth request should be rate limited
+    res = client.post('/api/meeting-events', json={})
+    assert res.status_code == 429


### PR DESCRIPTION
## Summary
- expand health check blueprint to verify OpenAI key, vector DB path, webhook secrets, and rate limiter buckets
- introduce app factory with `/api/meeting-events` endpoint protected by token-bucket rate limiting and cost tracking
- add unit tests for health check and rate limiting decorators

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests', 'tiktoken', etc.)*
- `pytest tests/test_healthz_full.py tests/test_rate_limit.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af2fa19d00832380614f7b89a4c3aa