### PR TITLE
Add realtime question detection pipeline with read-back alignment

### DIFF
--- a/app/asr_vad.py
+++ b/app/asr_vad.py
@@ -1,0 +1,117 @@
+"""Streaming ASR + VAD utilities.
+
+This module provides a minimal real‑time transcription helper that combines
+``webrtcvad`` for voice activity detection with ``faster_whisper`` for
+transcription of detected speech segments.  A very small rule‑based diarizer is
+included so that the speaker can be labelled ``user`` or ``other``.  The
+implementation is intentionally lightweight and pluggable – the diarizer can be
+replaced with a pyannote pipeline in the future.
+"""
+
+from dataclasses import dataclass
+from typing import Iterable, List, Tuple
+
+try:  # pragma: no cover - optional dependency
+    import webrtcvad
+except Exception:  # pragma: no cover
+    webrtcvad = None  # type: ignore
+
+try:  # pragma: no cover - model loading is expensive and not exercised in tests
+    from faster_whisper import WhisperModel
+except Exception:  # pragma: no cover
+    WhisperModel = None  # type: ignore
+
+SAMPLE_RATE = 16000
+FRAME_MS = 20
+FRAME_BYTES = int(SAMPLE_RATE * FRAME_MS / 1000) * 2  # 16‑bit audio
+
+
+class RuleBasedDiarizer:
+    """Very small diarizer stub using energy threshold."""
+
+    def __init__(self, threshold: int = 500):
+        self.threshold = threshold
+
+    def label(self, frame: bytes) -> str:
+        if not frame:
+            return "other"
+        # simple energy check
+        energy = sum(abs(b - 128) for b in frame) / len(frame)
+        return "other" if energy > self.threshold else "user"
+
+
+@dataclass
+class ReadBackAligner:
+    """Tracks how far the user has read back an answer."""
+
+    answer: str
+    cursor: int = 0
+
+    def update(self, spoken: str, window: int = 10) -> int:
+        """Fuzzy match the last ``window`` words and advance cursor."""
+        import difflib
+
+        answer_lower = self.answer.lower()
+        words = spoken.strip().split()
+        if not words:
+            return self.cursor
+
+        window_words = words[-window:]
+        segment = " ".join(window_words).lower()
+
+        # Exact match first
+        idx = answer_lower.find(segment)
+        if idx != -1:
+            self.cursor = idx + len(segment)
+            return self.cursor
+
+        # Fall back to fuzzy match
+        matcher = difflib.SequenceMatcher(None, answer_lower, segment)
+        match = matcher.find_longest_match(0, len(answer_lower), 0, len(segment))
+        self.cursor = match.a + match.size
+        return self.cursor
+
+
+class StreamingASR:
+    """Combine VAD, diarization and whisper into a streaming interface."""
+
+    def __init__(self):
+        self.vad = webrtcvad.Vad(2) if webrtcvad else None
+        self.buffer = b""
+        self.diarizer = RuleBasedDiarizer()
+        self.model = None  # lazy load
+
+    # ------------------------------------------------------------------
+    def _ensure_model(self):  # pragma: no cover - heavy
+        if self.model is None and WhisperModel is not None:
+            self.model = WhisperModel("tiny", device="cpu", compute_type="int8")
+
+    def _frames(self, chunk: bytes) -> Iterable[bytes]:
+        self.buffer += chunk
+        while len(self.buffer) >= FRAME_BYTES:
+            frame = self.buffer[:FRAME_BYTES]
+            self.buffer = self.buffer[FRAME_BYTES:]
+            yield frame
+
+    def transcribe_stream(self, chunk: bytes) -> Iterable[Tuple[str, str]]:
+        """Yield ``(speaker, text)`` pairs for speech in ``chunk``."""
+        speech_frames: List[bytes] = []
+        for frame in self._frames(chunk):
+            is_speech = self.vad.is_speech(frame, SAMPLE_RATE) if self.vad else True
+            if is_speech:
+                speech_frames.append(frame)
+            elif speech_frames:
+                yield from self._flush_frames(speech_frames)
+                speech_frames = []
+        if speech_frames:
+            yield from self._flush_frames(speech_frames)
+
+    def _flush_frames(self, frames: List[bytes]) -> Iterable[Tuple[str, str]]:
+        speaker = self.diarizer.label(b"".join(frames))
+        self._ensure_model()  # pragma: no cover
+        if self.model is None:  # pragma: no cover
+            text = ""  # model unavailable
+        else:  # pragma: no cover
+            segments, _ = self.model.transcribe(b"".join(frames), language="en")
+            text = " ".join(s.text for s in segments)
+        yield speaker, text.strip()

--- a/backend/realtime.py
+++ b/backend/realtime.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+"""Real-time audio processing pipeline.
+
+This module wires together VAD, ASR and question detection for streaming
+transcripts.  It is intentionally lightweight – heavy models are loaded lazily
+and can be swapped out later (e.g. pyannote for diarization).
+"""
+
+from dataclasses import dataclass
+from typing import Iterable, List, Optional
+
+from app.asr_vad import StreamingASR
+from app.question_detector import QuestionDetector, AnswerJob
+
+
+@dataclass
+class CaptionChunk:
+    """Caption text with diarized speaker information."""
+
+    speaker: str
+    text: str
+    ts: int  # milliseconds
+
+
+class RealtimePipeline:
+    """High level coordinator for real‑time caption processing."""
+
+    def __init__(self, asr: Optional[StreamingASR] = None,
+                 detector: Optional[QuestionDetector] = None):
+        self.asr = asr or StreamingASR()
+        self.detector = detector or QuestionDetector()
+
+    # --- audio ingest -------------------------------------------------
+    def process_audio_chunk(self, meeting_id: str, audio: bytes, ts: int) -> List[AnswerJob]:
+        """Process raw audio bytes and return any ``AnswerJob``s produced.
+
+        ``audio`` is assumed to be 16‑bit PCM at 16 kHz.  The ASR module takes
+        care of VAD and diarization, yielding partial transcript chunks which
+        are then fed to the question detector.
+        """
+        jobs: List[AnswerJob] = []
+        for speaker, text in self.asr.transcribe_stream(audio):
+            job = self.on_caption_chunk(meeting_id, speaker, text, ts)
+            if job:
+                jobs.append(job)
+        return jobs
+
+    # --- text ingest --------------------------------------------------
+    def on_caption_chunk(self, meeting_id: str, speaker: str,
+                         text: str, ts: int, score: float = 0.0) -> Optional[AnswerJob]:
+        """Feed caption chunks into the question detector.
+
+        When the detector signals an end of question an ``AnswerJob`` is
+        returned.  The caller may enqueue it for downstream processing.
+        """
+        question = self.detector.add_chunk(speaker=speaker, text=text, ts=ts, score=score)
+        if question:
+            return AnswerJob(meeting_id=meeting_id, question=question, timestamp=ts)
+        return None
+
+
+__all__ = ["RealtimePipeline", "CaptionChunk"]

--- a/overlay/reader.js
+++ b/overlay/reader.js
@@ -1,0 +1,42 @@
+// overlay/reader.js
+// Simple read‑back alignment helper used by the browser overlay.
+
+class ReadBackAligner {
+  constructor(answer) {
+    this.answer = answer || '';
+    this.cursor = 0;
+  }
+
+  update(spoken, windowSize = 10) {
+    const words = spoken.trim().split(/\s+/);
+    if (!words.length) return this.cursor;
+    const segment = words.slice(-windowSize).join(' ').toLowerCase();
+    const answerLower = this.answer.toLowerCase();
+    let idx = answerLower.indexOf(segment);
+    if (idx !== -1) {
+      this.cursor = idx + segment.length;
+      return this.cursor;
+    }
+    // fuzzy match via longest substring
+    let best = { a: 0, len: 0 };
+    for (let i = 0; i < answerLower.length; i++) {
+      for (let j = i; j < answerLower.length; j++) {
+        const sub = answerLower.slice(i, j + 1);
+        if (segment.includes(sub) && sub.length > best.len) {
+          best = { a: i, len: sub.length };
+        }
+      }
+    }
+    this.cursor = best.a + best.len;
+    return this.cursor;
+  }
+
+  scroll(container) {
+    if (!container) return;
+    const ratio = this.cursor / this.answer.length;
+    const target = ratio * (container.scrollHeight - container.clientHeight);
+    container.scrollTo({ top: target, behavior: 'smooth' });
+  }
+}
+
+window.ReadBackAligner = ReadBackAligner;

--- a/tests/test_alignment.py
+++ b/tests/test_alignment.py
@@ -1,0 +1,17 @@
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from app.asr_vad import ReadBackAligner
+
+def test_exact_match_advances_cursor():
+    answer = "The quick brown fox jumps over the lazy dog"
+    aligner = ReadBackAligner(answer)
+    idx = aligner.update("brown fox jumps")
+    target = answer.lower().index("brown fox jumps") + len("brown fox jumps")
+    assert abs(idx - target) <= 1
+
+def test_fuzzy_match_handles_partial_words():
+    answer = "Machine learning enables computers to learn from data"
+    aligner = ReadBackAligner(answer)
+    idx = aligner.update("learnin enables")
+    assert idx > 0

--- a/tests/test_question_detector.py
+++ b/tests/test_question_detector.py
@@ -1,0 +1,35 @@
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from app.question_detector import QuestionDetector
+
+
+def test_punctuation_triggers_boundary():
+    det = QuestionDetector(silence_ms=800)
+    ts = 0
+    text = "What is your name?"
+    q = det.add_chunk("other", text, ts)
+    assert q == text
+
+
+def test_silence_gap_triggers_boundary():
+    det = QuestionDetector(silence_ms=800)
+    ts = 0
+    det.add_chunk("other", "Tell me about yourself", ts)
+    ts += 900
+    q = det.add_chunk("other", "", ts)
+    assert q.startswith("Tell me")
+
+
+def test_classifier_score_triggers_boundary():
+    det = QuestionDetector(silence_ms=800, threshold=0.6)
+    ts = 0
+    q = det.add_chunk("other", "Please explain", ts, score=0.7)
+    assert q == "Please explain"
+
+
+def test_user_speaker_does_not_trigger():
+    det = QuestionDetector(silence_ms=800)
+    ts = 0
+    q = det.add_chunk("user", "Should not trigger?", ts)
+    assert q is None


### PR DESCRIPTION
## Summary
- wire realtime pipeline with VAD, ASR and question detector
- implement configurable question boundary detector and read-back alignment
- add overlay helper and unit tests for detector and alignment

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af348607808323a9af1421ea1080d1