### PR TITLE
Add note extraction and memory indexing for recordings

### DIFF
--- a/backend/memory_indexer.py
+++ b/backend/memory_indexer.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+"""Utilities for storing transcripts and notes in a persistent vector DB.
+
+The :class:`MemoryIndexer` class wraps access to ChromaDB while providing a
+light-weight fallback implementation when the dependency is not available.
+This makes the module usable in test environments without requiring the full
+vector database stack.
+"""
+
+import uuid
+from typing import Dict, List, Optional
+
+try:  # pragma: no cover - optional dependency
+    import chromadb  # type: ignore
+    from chromadb.config import Settings  # type: ignore
+except Exception:  # pragma: no cover - library optional
+    chromadb = None  # type: ignore
+    Settings = None  # type: ignore
+
+
+class MemoryIndexer:
+    """Index meeting artefacts into a vector store."""
+
+    def __init__(self, persist_dir: str = "./data/memory", metadata: Optional[Dict[str, str]] = None) -> None:
+        self.metadata_defaults = metadata or {}
+        if chromadb:
+            self.client = chromadb.Client(Settings(persist_directory=persist_dir))
+            self.transcript_collection = self.client.get_or_create_collection("transcripts")
+            self.notes_collection = self.client.get_or_create_collection("notes")
+        else:
+            # Fallback containers used in tests
+            self.client = None
+            self._transcripts: List[Dict] = []
+            self._notes: List[Dict] = []
+
+    # ------------------------------------------------------------------
+    def _merge_metadata(self, extra: Optional[Dict[str, str]]) -> Dict[str, str]:
+        meta = dict(self.metadata_defaults)
+        if extra:
+            meta.update(extra)
+        return meta
+
+    # ------------------------------------------------------------------
+    def upsert_transcript(self, meeting_id: str, text: str, metadata: Optional[Dict[str, str]] = None) -> str:
+        """Store a transcript chunk and return its identifier."""
+        meta = self._merge_metadata(metadata)
+        meta["meeting_id"] = meeting_id
+        doc_id = f"{meeting_id}_t_{uuid.uuid4()}"
+        if self.client:
+            self.transcript_collection.add(documents=[text], metadatas=[meta], ids=[doc_id])
+        else:
+            self._transcripts.append({"id": doc_id, "text": text, "metadata": meta})
+        return doc_id
+
+    def upsert_notes(self, meeting_id: str, notes: List[Dict[str, str]], metadata: Optional[Dict[str, str]] = None) -> List[str]:
+        """Store extracted notes."""
+        meta = self._merge_metadata(metadata)
+        ids = []
+        for note in notes:
+            note_meta = dict(meta)
+            note_meta.update(note)
+            note_meta["meeting_id"] = meeting_id
+            doc_id = f"{meeting_id}_n_{uuid.uuid4()}"
+            text = note.get("text", "")
+            if self.client:
+                self.notes_collection.add(documents=[text], metadatas=[note_meta], ids=[doc_id])
+            else:
+                self._notes.append({"id": doc_id, "note": note, "metadata": note_meta})
+            ids.append(doc_id)
+        return ids
+
+    # Accessors used in tests -------------------------------------------
+    @property
+    def stored_transcripts(self) -> List[Dict]:
+        if self.client:
+            raise RuntimeError("stored_transcripts only available without ChromaDB")
+        return self._transcripts
+
+    @property
+    def stored_notes(self) -> List[Dict]:
+        if self.client:
+            raise RuntimeError("stored_notes only available without ChromaDB")
+        return self._notes

--- a/backend/notes_extractor.py
+++ b/backend/notes_extractor.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+"""Simple heuristics for extracting meeting notes from transcripts.
+
+This module detects decisions and action items from a block of
+transcribed text. The extractor looks for keywords such as
+``DECISION:`` or ``ACTION:`` and attempts to parse optional owners
+(``@alice``) and deadlines (``2023-10-01``).
+
+Returned notes are dictionaries with the following keys:
+    * ``type`` – either ``decision`` or ``action``
+    * ``text`` – the free form note text
+    * ``owner`` – owner username if detected
+    * ``due`` – ISO date string if detected
+
+These structures can be fed directly into :mod:`backend.memory_indexer`
+for long-term storage.
+"""
+
+import re
+from typing import Dict, List
+
+# Regular expression patterns
+_DECISION_RE = re.compile(r"(?i)\bdecision\s*:\s*(?P<text>.+)")
+_ACTION_RE = re.compile(r"(?i)\baction(?:\s*item)?\s*:\s*(?P<text>.+)")
+_OWNER_RE = re.compile(r"@(?P<owner>[\w.-]+)")
+_DATE_RE = re.compile(r"(?P<due>\d{4}-\d{2}-\d{2})")
+
+
+def extract_notes(transcript: str) -> List[Dict[str, str]]:
+    """Extract structured notes from a transcript string.
+
+    Parameters
+    ----------
+    transcript: str
+        The raw transcript text to analyse.
+
+    Returns
+    -------
+    List[Dict[str, str]]
+        A list of extracted notes. Each note contains at least ``type`` and
+        ``text`` keys. ``owner`` and ``due`` are included when detected.
+    """
+
+    notes: List[Dict[str, str]] = []
+    for line in transcript.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+
+        # Decision lines -------------------------------------------------
+        m = _DECISION_RE.search(line)
+        if m:
+            notes.append({"type": "decision", "text": m.group("text").strip()})
+            continue
+
+        # Action lines ---------------------------------------------------
+        m = _ACTION_RE.search(line)
+        if m:
+            text = m.group("text").strip()
+            owner_match = _OWNER_RE.search(text)
+            due_match = _DATE_RE.search(text)
+            owner = owner_match.group("owner") if owner_match else None
+            due = due_match.group("due") if due_match else None
+
+            # Clean text by removing owner and due fragments
+            if owner_match:
+                text = text.replace(owner_match.group(0), "").strip()
+            if due_match:
+                # Remove the due date and any preceding 'due' token
+                text = re.sub(r"\b(due\s*)?" + re.escape(due_match.group("due")), "", text, flags=re.IGNORECASE).strip()
+
+            note = {"type": "action", "text": text}
+            if owner:
+                note["owner"] = owner
+            if due:
+                note["due"] = due
+            notes.append(note)
+
+    return notes

--- a/backend/server.py
+++ b/backend/server.py
@@ -60,6 +60,34 @@ def health():
         'integrations': status
     })
 
+# --- Recordings & Transcripts -----------------------------------------
+@app.route('/api/recordings/<meeting_id>', methods=['GET'])
+def list_recordings(meeting_id: str):
+    """List encrypted recording chunks for a meeting."""
+    dir_path = os.path.join('data', 'recordings')
+    files = []
+    if os.path.isdir(dir_path):
+        files = [f for f in os.listdir(dir_path) if f.startswith(meeting_id)]
+    return jsonify({'chunks': files})
+
+@app.route('/api/transcripts/<meeting_id>', methods=['GET'])
+def get_transcript(meeting_id: str):
+    """Return transcript JSONL entries for a meeting."""
+    path = os.path.join('data', 'transcripts', f'{meeting_id}.jsonl')
+    if not os.path.exists(path):
+        return jsonify([])
+    entries = []
+    with open(path, 'r', encoding='utf-8') as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entries.append(json.loads(line))
+            except Exception:
+                continue
+    return jsonify(entries)
+
 # --- Approvals REST API ---
 @app.route("/api/approvals", methods=['GET'])
 @subscription_required

--- a/recorder/__init__.py
+++ b/recorder/__init__.py
@@ -1,0 +1,7 @@
+"""Cross-platform recorder CLI placeholder.
+
+This package contains a minimal command-line interface for starting and
+stopping screen/audio recordings. The actual capture implementation is
+platform specific and outside the scope of the tests; the CLI mainly
+wires through to :mod:`backend.recording_service` for storage.
+"""

--- a/recorder/cli.py
+++ b/recorder/cli.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+"""Command line interface for the recording service.
+
+The CLI is intentionally lightweight: it does not perform real screen or
+system audio capture. Instead it demonstrates how a front-end could
+interact with :class:`backend.recording_service.RecordingService`. The
+``start`` command creates an empty encrypted chunk to simulate the first
+segment of a recording. ``stop`` currently only logs a message.
+"""
+
+import argparse
+import os
+from backend.recording_service import RecordingService
+
+
+def _simulate_chunk() -> bytes:
+    """Return placeholder bytes representing a 20s media chunk."""
+    return b"\x00" * 10  # trivial stand-in for encoded media
+
+
+def start_recording(meeting_id: str) -> None:
+    service = RecordingService()
+    service.save_chunk(meeting_id, _simulate_chunk(), 0)
+    print(f"recording started for {meeting_id}")
+
+
+def stop_recording(meeting_id: str) -> None:
+    print(f"recording stopped for {meeting_id}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="recorder")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_start = sub.add_parser("start", help="begin recording")
+    p_start.add_argument("--meetingId", required=True, dest="meeting_id")
+    p_start.add_argument("--window")
+    p_start.add_argument("--display", type=int)
+
+    p_stop = sub.add_parser("stop", help="stop recording")
+    p_stop.add_argument("--meetingId", required=True, dest="meeting_id")
+
+    args = parser.parse_args(argv)
+
+    if args.command == "start":
+        start_recording(args.meeting_id)
+    elif args.command == "stop":
+        stop_recording(args.meeting_id)
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    raise SystemExit(main())

--- a/tests/fixtures/sample_transcript.txt
+++ b/tests/fixtures/sample_transcript.txt
@@ -1,0 +1,4 @@
+Team meeting today.
+DECISION: We'll adopt microservices architecture.
+ACTION: @alice implement the API gateway due 2023-10-01.
+ACTION ITEM: finalize budget @bob due 2023-09-15.

--- a/tests/test_memory_indexer.py
+++ b/tests/test_memory_indexer.py
@@ -1,0 +1,31 @@
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from backend import memory_indexer as mi
+from backend.memory_indexer import MemoryIndexer
+
+
+def test_upsert_transcript_and_notes(monkeypatch):
+    # Force fallback mode by disabling chromadb
+    monkeypatch.setattr(mi, "chromadb", None)
+
+    indexer = MemoryIndexer(metadata={
+        "team": "core",
+        "repo": "mentor_app",
+        "jira": "MAPP",
+        "date": "2023-09-01",
+    })
+
+    tid = indexer.upsert_transcript("meeting1", "hello world")
+    assert indexer.stored_transcripts[0]["id"] == tid
+    meta = indexer.stored_transcripts[0]["metadata"]
+    assert meta["team"] == "core"
+    assert meta["meeting_id"] == "meeting1"
+
+    notes = [{"type": "action", "text": "do thing", "owner": "alice"}]
+    ids = indexer.upsert_notes("meeting1", notes)
+    assert len(ids) == 1
+    nmeta = indexer.stored_notes[0]["metadata"]
+    assert nmeta["owner"] == "alice"
+    assert nmeta["meeting_id"] == "meeting1"
+    assert nmeta["team"] == "core"

--- a/tests/test_notes_extractor.py
+++ b/tests/test_notes_extractor.py
@@ -1,0 +1,27 @@
+import os, sys
+import pathlib
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from backend.notes_extractor import extract_notes
+
+
+import pytest
+
+
+@pytest.fixture
+def sample_transcript():
+    path = pathlib.Path(__file__).parent / "fixtures" / "sample_transcript.txt"
+    return path.read_text()
+
+
+def test_extract_notes(sample_transcript):
+    notes = extract_notes(sample_transcript)
+    assert any(n["type"] == "decision" for n in notes)
+    actions = [n for n in notes if n["type"] == "action"]
+    assert len(actions) == 2
+    first = actions[0]
+    assert first["owner"] == "alice"
+    assert first["due"] == "2023-10-01"
+    second = actions[1]
+    assert second["owner"] == "bob"
+    assert second["due"] == "2023-09-15"


### PR DESCRIPTION
## Summary
- extract decisions and action items from transcripts
- index transcript chunks and notes into ChromaDB or fallback store
- add API routes for retrieving recording chunks and transcripts
- scaffold recorder CLI for start/stop operations
- unit tests for note extractor and memory indexer

## Testing
- `pytest`
- `npm test` *(fails: browserType.launch: Executable doesn't exist; run `npx playwright install`)*

------
https://chatgpt.com/codex/tasks/task_e_68af3717f6548323a55ab830f7bb6ab0