### PR TITLE
feat: add context and prompt builders with token budgeting

### DIFF
--- a/backend/context_builder.py
+++ b/backend/context_builder.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+import math
+from typing import Any, Dict, List
+
+
+@dataclass
+class Document:
+    """Simple representation of a stored document."""
+
+    text: str
+    doc_type: str
+    created_at: datetime
+    metadata: Dict[str, Any]
+    score: float = 1.0
+
+
+def count_tokens(text: str) -> int:
+    """Very small token estimator used for budgeting."""
+
+    return len(text.split())
+
+
+class ContextBuilder:
+    """Aggregates user context from a vector store with prioritisation.
+
+    The builder fetches documents for the user from a Chroma-like client and
+    orders them by document type priority and recency.  A token budget is
+    enforced so that lower priority documents are truncated first.
+    """
+
+    PRIORITY = {"jira": 3, "meeting": 2, "repo": 1}
+
+    def __init__(self, chroma_client, token_budget: int = 8000, top_k: int = 5, decay: float = 0.01) -> None:
+        self.chroma = chroma_client
+        self.token_budget = token_budget
+        self.top_k = top_k
+        self.decay = decay
+
+    def _retrieve(self, user_id: str, doc_type: str) -> List[Document]:
+        results = self.chroma.query(user_id=user_id, doc_type=doc_type, top_k=self.top_k)
+        docs: List[Document] = []
+        for r in results:
+            docs.append(
+                Document(
+                    text=r["text"],
+                    doc_type=doc_type,
+                    created_at=r["created_at"],
+                    metadata=r.get("metadata", {}),
+                    score=r.get("score", 1.0),
+                )
+            )
+        return docs
+
+    def build(self, user_id: str) -> Dict[str, Any]:
+        profile_docs = self._retrieve(user_id, "profile")
+        profile = profile_docs[0] if profile_docs else None
+
+        docs: List[Document] = []
+        for doc_type in ("jira", "meeting", "repo"):
+            docs.extend(self._retrieve(user_id, doc_type))
+
+        now = datetime.utcnow()
+        for d in docs:
+            age_days = (now - d.created_at).total_seconds() / (3600 * 24)
+            d.score = d.score * math.exp(-self.decay * age_days)
+
+        docs.sort(key=lambda d: (self.PRIORITY[d.doc_type], d.score), reverse=True)
+
+        context: Dict[str, Any] = {
+            "profile": profile.text if profile else "",
+            "level": profile.metadata.get("level") if profile else "",
+            "jira": [],
+            "meetings": [],
+            "repo": [],
+            "ordered": [],
+        }
+
+        total_tokens = count_tokens(context["profile"])
+
+        for d in docs:
+            tokens = count_tokens(d.text)
+            if total_tokens + tokens > self.token_budget:
+                continue
+            total_tokens += tokens
+            if d.doc_type == "jira":
+                context["jira"].append(d.text)
+            elif d.doc_type == "meeting":
+                context["meetings"].append(d.text)
+            else:
+                context["repo"].append(d.text)
+            context["ordered"].append((d.doc_type, d.text))
+
+        context["token_count"] = total_tokens
+        return context

--- a/backend/prompt_builder.py
+++ b/backend/prompt_builder.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from .context_builder import count_tokens
+
+
+class PromptBuilder:
+    """Constructs an LLM prompt using a consistent senior voice."""
+
+    def __init__(self, max_tokens: int = 8000) -> None:
+        self.max_tokens = max_tokens
+
+    def _render(self, question: str, context: Dict[str, Any]) -> str:
+        voice = f"You are an experienced {context.get('level', 'IC6')} engineer."
+        lines: List[str] = [voice, "", "What we know:"]
+        if context.get("profile"):
+            lines.append(f"- Resume: {context['profile']}")
+        if context.get("jira"):
+            lines.append(f"- Jira: {' '.join(context['jira'])}")
+        if context.get("meetings"):
+            lines.append(f"- Meetings: {' '.join(context['meetings'])}")
+        if context.get("repo"):
+            lines.append(f"- Repo: {' '.join(context['repo'])}")
+        lines.extend(["", f"Question: {question}"])
+        return "\n".join(lines)
+
+    def build(self, question: str, context: Dict[str, Any]) -> str:
+        prompt = self._render(question, context)
+        tokens = count_tokens(prompt)
+        if tokens <= self.max_tokens:
+            return prompt
+
+        # Truncate lower priority sections if we exceed the budget.  We mutate
+        # the context lists and re-render until within the limit.
+        priority_order = ["repo", "meetings", "jira"]
+        while tokens > self.max_tokens:
+            for key in priority_order:
+                if context.get(key):
+                    context[key] = context[key][:-1]
+                    break
+            prompt = self._render(question, context)
+            tokens = count_tokens(prompt)
+        return prompt

--- a/tests/test_context_prompt_builder.py
+++ b/tests/test_context_prompt_builder.py
@@ -1,0 +1,85 @@
+import os
+import sys
+from datetime import datetime, timedelta
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from backend.context_builder import ContextBuilder
+from backend.prompt_builder import PromptBuilder
+
+
+class MockChroma:
+    def __init__(self, docs):
+        self.docs = docs
+
+    def query(self, user_id, doc_type, top_k):
+        matched = [d for d in self.docs if d["user_id"] == user_id and d["doc_type"] == doc_type]
+        return matched[:top_k]
+
+
+def make_doc(user_id, doc_type, text, days_ago, metadata=None):
+    return {
+        "user_id": user_id,
+        "doc_type": doc_type,
+        "text": text,
+        "created_at": datetime.utcnow() - timedelta(days=days_ago),
+        "metadata": metadata or {},
+    }
+
+
+def test_context_ordering_and_budget():
+    docs = [
+        make_doc("u1", "profile", "senior summary", 100, {"level": "IC7"}),
+        make_doc("u1", "jira", "jira one item", 1),
+        make_doc("u1", "jira", "jira two item", 2),
+        make_doc("u1", "meeting", "meeting one", 1),
+        make_doc("u1", "repo", "repo one", 2),
+        make_doc("u1", "repo", "repo two", 1),
+    ]
+    chroma = MockChroma(docs)
+    builder = ContextBuilder(chroma, token_budget=12)
+    context = builder.build("u1")
+
+    assert context["jira"] == ["jira one item", "jira two item"]
+    assert context["meetings"] == ["meeting one"]
+    assert context["repo"] == ["repo two"]  # oldest repo doc trimmed
+    assert context["token_count"] <= 12
+
+
+def test_context_priority_drops_lowest():
+    docs = [
+        make_doc("u1", "profile", "senior summary", 100, {"level": "IC6"}),
+        make_doc("u1", "jira", "jira one item", 1),
+        make_doc("u1", "jira", "jira two item", 2),
+        make_doc("u1", "meeting", "meeting one", 1),
+        make_doc("u1", "repo", "repo one", 1),
+    ]
+    chroma = MockChroma(docs)
+    builder = ContextBuilder(chroma, token_budget=8)
+    context = builder.build("u1")
+
+    assert context["jira"] == ["jira one item", "jira two item"]
+    assert context["meetings"] == []
+    assert context["repo"] == []
+    assert context["token_count"] <= 8
+
+
+def test_prompt_builder_voice_block():
+    docs = [
+        make_doc("u1", "profile", "senior summary", 100, {"level": "IC7"}),
+        make_doc("u1", "jira", "jira issue", 1),
+        make_doc("u1", "meeting", "meeting notes", 1),
+        make_doc("u1", "repo", "repo summary", 1),
+    ]
+    chroma = MockChroma(docs)
+    context = ContextBuilder(chroma, token_budget=50).build("u1")
+
+    pb = PromptBuilder(max_tokens=50)
+    prompt = pb.build("How do we scale?", context)
+
+    assert "IC7" in prompt
+    assert "What we know:" in prompt
+    assert "Resume: senior summary" in prompt
+    assert "Jira: jira issue" in prompt
+    assert "Meetings: meeting notes" in prompt
+    assert "Repo: repo summary" in prompt


### PR DESCRIPTION
## Summary
- implement ContextBuilder for recency-aware retrieval with doc-type priority and token budgeting
- add PromptBuilder that applies user level voice and structured "what we know" block
- tests verifying ordering, priority-based truncation, and prompt building

## Testing
- `pytest tests/test_context_prompt_builder.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af393c7bb483238dc0defe852ed1ca