### PR TITLE
Add Jira approvals workflow and webhook verification

### DIFF
--- a/backend/approval_worker.py
+++ b/backend/approval_worker.py
@@ -7,9 +7,10 @@ log = logging.getLogger(__name__)
 # Import managers to avoid circular imports
 def get_managers():
     from backend.integrations.github_manager import GitHubManager
-    from backend.integrations.jira_manager import JiraManager
+    from integrations.jira_client import JiraClient
     from backend.approvals import approvals
-    return GitHubManager(dry_run=True), JiraManager(dry_run=True), approvals
+    dry_run = os.getenv("APP_ENV", "").lower() != "prod"
+    return GitHubManager(dry_run=dry_run), JiraClient(dry_run=dry_run), approvals
 
 # Initialize managers (dry_run=True by default for safety)
 github, jira, approvals = get_managers()

--- a/backend/server.py
+++ b/backend/server.py
@@ -18,7 +18,9 @@ CORS(app)
 
 # Ship-It PR: Add healthz blueprint
 from backend.healthz import bp as healthz_bp
+from backend.webhooks_jira import bp as jira_bp
 app.register_blueprint(healthz_bp)
+app.register_blueprint(jira_bp)
 
 # Ship-It PR: Add middleware for rate limiting and cost tracking
 from backend.middleware import rate_limit, record_cost

--- a/backend/webhooks_jira.py
+++ b/backend/webhooks_jira.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+from flask import Blueprint, request, jsonify
+from typing import Any, List
+
+from backend.webhook_signatures import verify_jira
+from backend.memory_service import MemoryService
+from backend.approvals import propose_jira_from_notes
+from backend.payments import subscription_required
+
+bp = Blueprint('jira', __name__)
+mem = MemoryService()
+
+@bp.route('/webhook/jira', methods=['POST'])
+def jira_webhook():
+    """Handle Jira webhook callbacks with signature verification."""
+    sig = request.headers.get('X-Shared-Secret', '')
+    body = request.get_data()
+    if not verify_jira(sig, body):
+        return "", 401
+    payload = request.get_json(force=True) or {}
+    issue = payload.get('issue', {})
+    key = issue.get('key')
+    fields = issue.get('fields', {})
+    summary = fields.get('summary', '')
+    status = (fields.get('status') or {}).get('name', '')
+    if key:
+        text = f"[{key}] {summary} — status: {status}"
+        mem.add_task(key, text, metadata={'summary': summary, 'status': status, 'jira_key': key})
+    return "", 204
+
+@bp.route('/api/propose-jira', methods=['POST'])
+@subscription_required
+def propose_jira():
+    """Create approvals for Jira tickets derived from meeting notes."""
+    data = request.get_json(force=True) or {}
+    project_key = data.get('project_key') or data.get('project')
+    notes: List[Any] = data.get('notes') or []
+    if not project_key or not isinstance(notes, list):
+        return jsonify({'error': 'Missing project_key or notes'}), 400
+    items = propose_jira_from_notes(project_key, notes)
+    return jsonify({
+        'submitted': len(items),
+        'approvals': [vars(i) for i in items]
+    })

--- a/integrations/jira_client.py
+++ b/integrations/jira_client.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+import os, base64, requests
+from typing import Dict, Any, Optional
+
+class JiraClient:
+    """Minimal Jira client used by approvals worker."""
+
+    def __init__(self, dry_run: Optional[bool] = None):
+        self.base = os.getenv("JIRA_BASE_URL", "")
+        self.user = os.getenv("JIRA_USER", "")
+        self.token = os.getenv("JIRA_TOKEN", "")
+        if dry_run is None:
+            self.dry_run = os.getenv("APP_ENV", "").lower() != "prod"
+        else:
+            self.dry_run = dry_run
+
+    def _headers(self) -> Dict[str, str]:
+        raw = f"{self.user}:{self.token}".encode()
+        encoded = base64.b64encode(raw).decode()
+        return {"Authorization": "Basic " + encoded, "Content-Type": "application/json"}
+
+    def create_issue(self, project_key: str, summary: str, description: str, issue_type: str = "Task") -> Dict[str, Any]:
+        payload = {
+            "fields": {
+                "project": {"key": project_key},
+                "summary": summary,
+                "issuetype": {"name": issue_type},
+                "description": description,
+            }
+        }
+        if self.dry_run:
+            return {"dry_run": True, "payload": payload}
+        r = requests.post(f"{self.base}/rest/api/3/issue", headers=self._headers(), json=payload, timeout=30)
+        r.raise_for_status()
+        return r.json()
+
+    def update_issue(self, key: str, fields: Dict[str, Any]) -> Dict[str, Any]:
+        if self.dry_run:
+            return {"dry_run": True, "key": key, "fields": fields}
+        r = requests.put(f"{self.base}/rest/api/3/issue/{key}", headers=self._headers(), json={"fields": fields}, timeout=30)
+        r.raise_for_status()
+        return r.json()
+
+    def search(self, jql: str, max_results: int = 50) -> Dict[str, Any]:
+        if self.dry_run:
+            return {"dry_run": True, "jql": jql, "issues": []}
+        params = {"jql": jql, "maxResults": max_results}
+        r = requests.get(f"{self.base}/rest/api/3/search", headers=self._headers(), params=params, timeout=30)
+        r.raise_for_status()
+        return r.json()
+
+    def add_comment(self, key: str, comment: str) -> Dict[str, Any]:
+        if self.dry_run:
+            return {"dry_run": True, "key": key, "comment": comment}
+        r = requests.post(f"{self.base}/rest/api/3/issue/{key}/comment", headers=self._headers(), json={"body": comment}, timeout=30)
+        r.raise_for_status()
+        return r.json()
+
+    def transition_issue(self, key: str, transition_id: str, comment: Optional[str] = None) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {"transition": {"id": transition_id}}
+        if comment:
+            payload["update"] = {"comment": [{"add": {"body": comment}}]}
+        if self.dry_run:
+            return {"dry_run": True, "key": key, "transition_id": transition_id, "comment": comment}
+        r = requests.post(f"{self.base}/rest/api/3/issue/{key}/transitions", headers=self._headers(), json=payload, timeout=30)
+        r.raise_for_status()
+        return r.json()

--- a/tests/test_jira_integration.py
+++ b/tests/test_jira_integration.py
@@ -1,0 +1,86 @@
+import json, hmac, hashlib, os, sys, types
+import pytest
+
+sys.path.append(os.getcwd())
+
+
+def setup_app(monkeypatch):
+    """Create a minimal Flask app with only the needed routes."""
+    monkeypatch.setenv('JIRA_WEBHOOK_SECRET', 'secret')
+    # Stub module to avoid OpenAI dependency
+    sys.modules['backend.pr_auto_reply'] = types.SimpleNamespace(
+        suggest_replies_and_patch=lambda *a, **k: {"raw": "{}"}
+    )
+
+    from flask import Flask, request, jsonify
+    from backend.webhook_signatures import verify_jira
+    from backend.approvals import approvals, propose_jira_from_notes
+    from backend.approval_worker import on_approval_resolved
+
+    app = Flask(__name__)
+
+    @app.route('/webhook/jira', methods=['POST'])
+    def jira_webhook():
+        sig = request.headers.get('X-Shared-Secret', '')
+        body = request.get_data()
+        if not verify_jira(sig, body):
+            return '', 401
+        payload = request.get_json(force=True) or {}
+        issue = payload.get('issue', {})
+        key = issue.get('key')
+        fields = issue.get('fields', {})
+        summary = fields.get('summary', '')
+        status = (fields.get('status') or {}).get('name', '')
+        if key:
+            pass  # memory update stubbed out
+        return '', 204
+
+    @app.route('/api/propose-jira', methods=['POST'])
+    def propose():
+        data = request.get_json(force=True) or {}
+        project_key = data.get('project_key')
+        notes = data.get('notes', [])
+        items = propose_jira_from_notes(project_key, notes)
+        return jsonify({'submitted': len(items), 'approvals': [vars(i) for i in items]})
+
+    @app.route('/api/approvals/resolve', methods=['POST'])
+    def resolve():
+        data = request.get_json(force=True)
+        item = approvals.resolve(data['id'], data['decision'])
+        item['exec_result'] = on_approval_resolved(item)
+        return jsonify(item)
+
+    return app
+
+
+def test_webhook_signature(monkeypatch):
+    app = setup_app(monkeypatch)
+    client = app.test_client()
+    payload = {'issue': {'key': 'ENG-1', 'fields': {'summary': 'test', 'status': {'name': 'Open'}}}}
+    body = json.dumps(payload).encode()
+    sig = hmac.new(b'secret', body, hashlib.sha256).hexdigest()
+    resp = client.post('/webhook/jira', data=body, headers={'Content-Type': 'application/json', 'X-Shared-Secret': sig})
+    assert resp.status_code == 204
+    resp = client.post('/webhook/jira', data=body, headers={'Content-Type': 'application/json', 'X-Shared-Secret': 'bad'})
+    assert resp.status_code == 401
+
+
+def test_propose_jira_approval_flow(monkeypatch):
+    app = setup_app(monkeypatch)
+    client = app.test_client()
+    called = {}
+
+    def fake_create_issue(self, project_key, summary, description, issue_type='Task'):
+        called['args'] = (project_key, summary, description)
+        return {'ok': True}
+
+    monkeypatch.setattr('integrations.jira_client.JiraClient.create_issue', fake_create_issue)
+
+    resp = client.post('/api/propose-jira', json={'project_key': 'ENG', 'notes': ['Do thing']})
+    assert resp.status_code == 200
+    approval_id = resp.get_json()['approvals'][0]['id']
+    assert called == {}
+
+    resp = client.post('/api/approvals/resolve', json={'id': approval_id, 'decision': 'approve'})
+    assert resp.status_code == 200
+    assert called['args'][0] == 'ENG'


### PR DESCRIPTION
## Summary
- add minimal Jira client with create/update/search and DRY_RUN defaults
- add endpoint to propose Jira issues from notes and webhook to sync issue status
- process Jira approvals via worker only on approval

## Testing
- `pytest -q`
- `pytest tests/test_jira_integration.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68af3b8afca483239a55d2319f224059