### PR TITLE
Add GitHub webhook handler and patch suggester

### DIFF
--- a/backend/patch_suggester.py
+++ b/backend/patch_suggester.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+import re
+
+
+def suggest_patch(log: str) -> str:
+    """Generate a minimal patch suggestion from a CI log.
+
+    Supports two simple heuristics:
+    - Missing Python dependency (ModuleNotFoundError) -> add to requirements.txt
+    - Failing assertion in tests -> replace expected value with actual value
+    """
+    # Dependency missing
+    m = re.search(r"ModuleNotFoundError: No module named '([^']+)'", log)
+    if m:
+        pkg = m.group(1)
+        return (
+            "--- a/requirements.txt\n"
+            "+++ b/requirements.txt\n"
+            "@@\n"
+            f" {pkg}\n"
+        )
+
+    # Simple pytest assertion mismatch
+    m = re.search(
+        r">[^\n]*assert ([^\n]+)\nE\s+AssertionError: assert ([^\n]+)\n\n([^:]+\.py):", log
+    )
+    if m:
+        expected_expr = m.group(1).strip()
+        actual_expr = m.group(2).strip()
+        file_path = m.group(3).strip()
+        return (
+            f"--- a/{file_path}\n"
+            f"+++ b/{file_path}\n"
+            "@@\n"
+            f"-assert {expected_expr}\n"
+            f"+assert {actual_expr}\n"
+        )
+
+    return ""
+
+
+def suggest_patch_from_url(url: str, timeout: int = 10) -> str:
+    """Fetch logs from ``url`` and run :func:`suggest_patch`.
+
+    This imports :mod:`requests` lazily to keep the dependency optional.
+    Returns empty string if the logs cannot be fetched or no patch is found.
+    """
+    try:
+        import requests  # type: ignore
+
+        r = requests.get(url, timeout=timeout)
+        r.raise_for_status()
+        return suggest_patch(r.text)
+    except Exception:
+        return ""

--- a/backend/webhooks_github.py
+++ b/backend/webhooks_github.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+from flask import Blueprint, request
+from typing import Any, Dict
+
+from backend.webhook_signatures import verify_github
+from backend.approvals import request_pr_auto_reply, approvals
+from backend.patch_suggester import suggest_patch_from_url
+
+bp = Blueprint("github", __name__)
+
+@bp.route("/webhook/github", methods=["POST"])
+def github_webhook():
+    """Handle GitHub webhook events with signature verification."""
+    sig = request.headers.get("X-Hub-Signature-256", "")
+    body = request.get_data()
+    if not verify_github(sig, body):
+        return "", 401
+
+    event = request.headers.get("X-GitHub-Event", "")
+    payload: Dict[str, Any] = request.get_json(force=True) or {}
+
+    if event == "pull_request":
+        action = payload.get("action")
+        if action in ("opened", "synchronize"):
+            repo_full = payload.get("repository", {}).get("full_name", "")
+            owner, repo = repo_full.split("/", 1) if "/" in repo_full else ("", repo_full)
+            pr_number = payload.get("pull_request", {}).get("number")
+            if owner and repo and pr_number:
+                request_pr_auto_reply(owner, repo, pr_number)
+    elif event == "workflow_run":
+        action = payload.get("action")
+        workflow = payload.get("workflow_run", {})
+        if action == "completed" and workflow.get("conclusion") == "failure":
+            logs_url = workflow.get("logs_url", "")
+            patch = suggest_patch_from_url(logs_url) if logs_url else ""
+            if patch:
+                approvals.submit("github.apply_patch", {"patch_content": patch})
+
+    return "", 204

--- a/integrations/github_manager.py
+++ b/integrations/github_manager.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+import os
+import base64
+import requests
+from typing import Dict, Any, Optional
+
+GITHUB_API = os.getenv("GITHUB_API", "https://api.github.com")
+GITHUB_TOKEN = os.getenv("GITHUB_TOKEN", "")
+
+def _headers() -> Dict[str, str]:
+    return {
+        "Authorization": f"Bearer {GITHUB_TOKEN}",
+        "Accept": "application/vnd.github+json",
+    }
+
+class GitHubManager:
+    """Minimal GitHub client used across backend components."""
+
+    def __init__(self, dry_run: Optional[bool] = None):
+        if dry_run is None:
+            self.dry_run = os.getenv("APP_ENV", "").lower() != "prod"
+        else:
+            self.dry_run = dry_run
+
+    # --- Write operations -------------------------------------------------
+    def comment_pr(self, owner: str, repo: str, pr_number: int, body: str) -> Dict[str, Any]:
+        """Post a comment on a pull request."""
+        if self.dry_run:
+            return {"dry_run": True, "pr": pr_number, "body": body}
+        r = requests.post(
+            f"{GITHUB_API}/repos/{owner}/{repo}/issues/{pr_number}/comments",
+            headers=_headers(),
+            json={"body": body},
+            timeout=30,
+        )
+        r.raise_for_status()
+        return r.json()
+
+    def create_branch(self, owner: str, repo: str, base_branch: str, new_branch: str) -> Dict[str, Any]:
+        """Create ``new_branch`` from ``base_branch``."""
+        if self.dry_run:
+            return {
+                "dry_run": True,
+                "owner": owner,
+                "repo": repo,
+                "base": base_branch,
+                "new": new_branch,
+            }
+        r = requests.get(
+            f"{GITHUB_API}/repos/{owner}/{repo}/git/ref/heads/{base_branch}",
+            headers=_headers(),
+            timeout=30,
+        )
+        r.raise_for_status()
+        sha = r.json()["object"]["sha"]
+        r = requests.post(
+            f"{GITHUB_API}/repos/{owner}/{repo}/git/refs",
+            headers=_headers(),
+            json={"ref": f"refs/heads/{new_branch}", "sha": sha},
+            timeout=30,
+        )
+        r.raise_for_status()
+        return r.json()
+
+    def commit_file(
+        self,
+        owner: str,
+        repo: str,
+        branch: str,
+        path: str,
+        content_bytes: bytes,
+        message: str,
+    ) -> Dict[str, Any]:
+        """Create or update a file on ``branch``."""
+        if self.dry_run:
+            return {"dry_run": True, "path": path, "branch": branch}
+        b64 = base64.b64encode(content_bytes).decode()
+        payload: Dict[str, Any] = {"message": message, "content": b64, "branch": branch}
+        try:
+            r = requests.get(
+                f"{GITHUB_API}/repos/{owner}/{repo}/contents/{path}?ref={branch}",
+                headers=_headers(),
+                timeout=30,
+            )
+            if r.status_code == 200:
+                payload["sha"] = r.json().get("sha")
+        except Exception:
+            pass
+        r = requests.put(
+            f"{GITHUB_API}/repos/{owner}/{repo}/contents/{path}",
+            headers=_headers(),
+            json=payload,
+            timeout=30,
+        )
+        r.raise_for_status()
+        return r.json()
+
+    def create_pr(
+        self,
+        owner: str,
+        repo: str,
+        head: str,
+        base: str,
+        title: str,
+        body: str = "",
+    ) -> Dict[str, Any]:
+        """Open a pull request."""
+        if self.dry_run:
+            return {"dry_run": True, "title": title, "head": head, "base": base}
+        r = requests.post(
+            f"{GITHUB_API}/repos/{owner}/{repo}/pulls",
+            headers=_headers(),
+            json={"title": title, "head": head, "base": base, "body": body},
+            timeout=30,
+        )
+        r.raise_for_status()
+        return r.json()

--- a/tests/test_github_signature.py
+++ b/tests/test_github_signature.py
@@ -1,0 +1,18 @@
+import hmac
+import hashlib
+import os
+import sys
+
+sys.path.append(os.getcwd())
+
+
+def test_verify_github_signature():
+    import backend.webhook_signatures as sig
+
+    sig.GITHUB_SECRET = "secret"
+    sig.JIRA_SECRET = "secret"
+    body = b"{}"
+    good_sig = "sha256=" + hmac.new(b"secret", body, hashlib.sha256).hexdigest()
+
+    assert sig.verify_github(good_sig, body)
+    assert not sig.verify_github("sha256=bad", body)

--- a/tests/test_patch_suggester.py
+++ b/tests/test_patch_suggester.py
@@ -1,0 +1,24 @@
+import os
+import sys
+
+sys.path.append(os.getcwd())
+
+from backend.patch_suggester import suggest_patch
+
+
+def test_suggest_patch_missing_dependency():
+    log = "ModuleNotFoundError: No module named 'samplepkg'"
+    patch = suggest_patch(log)
+    assert 'requirements.txt' in patch
+    assert 'samplepkg' in patch
+
+
+def test_suggest_patch_assertion_mismatch():
+    log = (
+        ">       assert add(1,2) == 4\n"
+        "E       AssertionError: assert 3 == 4\n\n"
+        "tests/test_math.py:5: AssertionError"
+    )
+    patch = suggest_patch(log)
+    assert 'tests/test_math.py' in patch
+    assert '+assert 3 == 4' in patch


### PR DESCRIPTION
## Summary
- implement minimal GitHub manager for commenting and PR automation
- add GitHub webhook handler that verifies signatures and queues approvals for PR events and workflow failures
- introduce patch suggester to generate minimal diffs from CI logs
- test webhook signature verification and patch suggestions

## Testing
- `pytest tests/test_github_signature.py tests/test_patch_suggester.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af3db4de00832399aca1e71a3aefe9