### PR TITLE
Wire meeting event ingestion through production services

### DIFF
--- a/backend/meeting_events.py
+++ b/backend/meeting_events.py
@@ -191,7 +191,7 @@ class MeetingEventRouter:
                 return int(raw)
             if raw > 10**9:
                 return int(raw * 1000)
-        return int(datetime.utcnow().timestamp() * 1000)
+        return int(datetime.now(timezone.utc).timestamp() * 1000)
 
     @staticmethod
     def _normalise_speaker_for_detector(speaker: str) -> str:

--- a/backend/meeting_events.py
+++ b/backend/meeting_events.py
@@ -1,0 +1,206 @@
+"""Utilities for routing meeting events into the intelligence stack.
+
+The browser extension and native capture clients post structured ``meeting
+events`` to the realtime service.  Historically the Flask endpoint simply
+acknowledged these payloads which meant that caption intelligence, question
+detection, and meeting summaries only worked when tests invoked the lower
+level helpers directly.  This module provides a lightweight in-memory router
+that wires those pieces together so the `/api/meeting-events` endpoint does
+useful work even in the single-process dev environment used by the tests.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+import logging
+from typing import Any, Deque, Dict, List, Optional
+
+from app.meeting_intelligence import meeting_intelligence
+from backend.realtime import RealtimePipeline
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class MeetingState:
+    """Runtime state for a meeting tracked via the router."""
+
+    meeting_id: str
+    session_id: Optional[str] = None
+    captions: Deque[Dict[str, Any]] = field(default_factory=lambda: deque(maxlen=200))
+    questions: List[Dict[str, Any]] = field(default_factory=list)
+    flags: Dict[str, Any] = field(default_factory=dict)
+    last_activity: datetime = field(default_factory=datetime.utcnow)
+
+
+class MeetingEventRouter:
+    """Process meeting events coming from browser/desktop capture clients."""
+
+    def __init__(self, pipeline: Optional[RealtimePipeline] = None):
+        self.pipeline = pipeline or RealtimePipeline()
+        self._meetings: Dict[str, MeetingState] = {}
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def handle_event(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Validate and route an incoming meeting event."""
+
+        action = (payload or {}).get("action")
+        data = (payload or {}).get("data") or {}
+        if not action:
+            raise ValueError("Missing 'action' in meeting event payload")
+
+        meeting_id = data.get("meetingId") or data.get("meeting_id")
+        if not meeting_id:
+            raise ValueError("Missing meeting identifier in event data")
+
+        handler = getattr(self, f"_handle_{action}", None)
+        state = self._ensure_state(meeting_id)
+        state.last_activity = datetime.utcnow()
+
+        if handler is None:
+            log.debug("No handler for meeting event action %s", action)
+            return {
+                "action": action,
+                "meeting_id": meeting_id,
+                "status": "ignored",
+            }
+
+        result = handler(state, data) or {}
+        result.setdefault("action", action)
+        result.setdefault("meeting_id", meeting_id)
+        return result
+
+    # ------------------------------------------------------------------
+    # Event handlers
+    # ------------------------------------------------------------------
+    def _handle_meeting_started(self, state: MeetingState, data: Dict[str, Any]) -> Dict[str, Any]:
+        participants_raw = data.get("participants") or []
+        participants: List[str] = []
+        for entry in participants_raw:
+            if isinstance(entry, str):
+                participants.append(entry)
+            elif isinstance(entry, dict):
+                for key in ("id", "email", "name"):
+                    value = entry.get(key)
+                    if value:
+                        participants.append(str(value))
+                        break
+
+        meeting_intelligence.start_meeting(state.meeting_id, participants)
+        state.session_id = data.get("sessionId") or data.get("session_id")
+        state.flags.update({k: v for k, v in data.items() if k not in {"meetingId", "meeting_id", "participants", "sessionId", "session_id"}})
+
+        return {
+            "status": "started",
+            "session_id": state.session_id,
+            "participants": participants,
+        }
+
+    def _handle_caption_chunk(self, state: MeetingState, data: Dict[str, Any]) -> Dict[str, Any]:
+        text = (data.get("text") or "").strip()
+        if not text:
+            return {"status": "skipped", "reason": "empty_text"}
+
+        speaker = (data.get("speaker") or "unknown").strip() or "unknown"
+        timestamp_raw = data.get("timestamp")
+        timestamp_dt = self._parse_timestamp(timestamp_raw)
+
+        analysis = meeting_intelligence.process_caption(
+            state.meeting_id,
+            text=text,
+            speaker_id=speaker,
+            timestamp=timestamp_dt,
+        )
+
+        caption_entry = {
+            "text": text,
+            "speaker": speaker,
+            "timestamp": timestamp_dt.isoformat() if timestamp_dt else None,
+        }
+        state.captions.append(caption_entry)
+
+        ts_ms = self._timestamp_ms(timestamp_dt, timestamp_raw)
+        detector_speaker = self._normalise_speaker_for_detector(speaker)
+        job = self.pipeline.on_caption_chunk(state.meeting_id, detector_speaker, text, ts_ms)
+
+        question_payload: Optional[Dict[str, Any]] = None
+        if job:
+            question_payload = {
+                "question": job.question,
+                "timestamp": job.timestamp,
+            }
+            state.questions.append(question_payload)
+
+        return {
+            "status": "processed",
+            "analysis": analysis,
+            "question_detected": question_payload is not None,
+            "question": question_payload,
+            "captions_buffered": len(state.captions),
+        }
+
+    def _handle_screen_shared(self, state: MeetingState, data: Dict[str, Any]) -> Dict[str, Any]:
+        active = bool(data.get("active", True))
+        state.flags["screen_shared"] = active
+        return {"status": "updated", "screen_shared": active}
+
+    def _handle_meeting_ended(self, state: MeetingState, data: Dict[str, Any]) -> Dict[str, Any]:
+        summary = meeting_intelligence.get_meeting_summary(state.meeting_id)
+        pending_questions = list(state.questions)
+        self._meetings.pop(state.meeting_id, None)
+        return {
+            "status": "ended",
+            "summary": summary,
+            "pending_questions": pending_questions,
+        }
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _ensure_state(self, meeting_id: str) -> MeetingState:
+        if meeting_id not in self._meetings:
+            self._meetings[meeting_id] = MeetingState(meeting_id=meeting_id)
+        return self._meetings[meeting_id]
+
+    @staticmethod
+    def _parse_timestamp(raw: Any) -> Optional[datetime]:
+        if isinstance(raw, datetime):
+            return raw
+        if isinstance(raw, (int, float)):
+            # Treat large values as milliseconds.
+            if raw > 10**12:
+                raw = raw / 1000.0
+            return datetime.fromtimestamp(raw, tz=timezone.utc).replace(tzinfo=None)
+        if isinstance(raw, str):
+            try:
+                return datetime.fromisoformat(raw.replace("Z", "+00:00")).astimezone(timezone.utc).replace(tzinfo=None)
+            except ValueError:
+                log.debug("Failed to parse timestamp %s", raw)
+        return None
+
+    @staticmethod
+    def _timestamp_ms(timestamp: Optional[datetime], raw: Any) -> int:
+        if timestamp:
+            return int(timestamp.replace(tzinfo=timezone.utc).timestamp() * 1000)
+        if isinstance(raw, (int, float)):
+            if raw > 10**12:
+                return int(raw)
+            if raw > 10**9:
+                return int(raw * 1000)
+        return int(datetime.utcnow().timestamp() * 1000)
+
+    @staticmethod
+    def _normalise_speaker_for_detector(speaker: str) -> str:
+        lower = speaker.lower()
+        if lower in {"interviewer", "recruiter", "panel", "other"}:
+            return "other"
+        if lower in {"candidate", "self", "me"}:
+            return "self"
+        return lower or "unknown"
+
+
+__all__ = ["MeetingEventRouter", "MeetingState"]

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,0 +1,371 @@
+import importlib
+import os
+import sys
+import uuid
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+
+def _reset_module(module_name: str) -> None:
+    """Remove a module from sys.modules if present to force a clean import."""
+    if module_name in sys.modules:
+        del sys.modules[module_name]
+
+
+def _mock_chat_completion(content: str):
+    """Create a lightweight object that mimics OpenAI's chat completion response."""
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=content))]
+    )
+
+
+def _install_stub_dependencies() -> None:
+    """Install lightweight stubs for optional heavy dependencies."""
+    class _StubDiarizationService:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def resolve_speaker(self, speaker_id):
+            return speaker_id
+
+        def assign_speaker_to_text(self, text):
+            return None
+
+    sys.modules.pop("backend.diarization_service", None)
+    sys.modules.setdefault(
+        "backend.diarization_service",
+        SimpleNamespace(DiarizationService=_StubDiarizationService),
+    )
+    sys.modules.pop("app.meeting_intelligence", None)
+
+    class _StubSummarizationService:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def generate_summary(self, text: str, summary_type: str = "meeting") -> str:
+            return f"Stub summary ({summary_type})"
+
+        def extract_action_items(self, text: str):
+            return []
+
+    sys.modules.pop("app.summarization", None)
+    sys.modules.setdefault(
+        "app.summarization",
+        SimpleNamespace(SummarizationService=_StubSummarizationService),
+    )
+
+    class _StubMemoryService:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def add_meeting_entry(self, *args, **kwargs):
+            return None
+
+    sys.modules.pop("backend.memory_service", None)
+    sys.modules.setdefault(
+        "backend.memory_service",
+        SimpleNamespace(MemoryService=_StubMemoryService),
+    )
+
+    class _StubOpenAI:
+        def __init__(self, *args, **kwargs):
+            self.chat = SimpleNamespace(
+                completions=SimpleNamespace(create=lambda *a, **k: _mock_chat_completion("stub"))
+            )
+
+    sys.modules.pop("openai", None)
+    sys.modules.setdefault("openai", SimpleNamespace(OpenAI=_StubOpenAI))
+
+    class _StubJWTExceptions(Exception):
+        pass
+
+    class _StubExpiredSignatureError(_StubJWTExceptions):
+        pass
+
+    class _StubInvalidTokenError(_StubJWTExceptions):
+        pass
+
+    token_store = {}
+
+    def _stub_encode(payload, secret, algorithm="HS256"):
+        token = f"stub-token-{uuid.uuid4()}"
+        token_store[token] = (payload, secret)
+        return token
+
+    def _stub_decode(token, secret, algorithms=None):
+        stored = token_store.get(token)
+        if not stored:
+            raise _StubInvalidTokenError("Unknown token")
+        payload, stored_secret = stored
+        if stored_secret != secret:
+            raise _StubInvalidTokenError("Secret mismatch")
+        exp = payload.get("exp")
+        if isinstance(exp, datetime) and exp < datetime.utcnow():
+            raise _StubExpiredSignatureError("Token expired")
+        return payload
+
+    sys.modules.pop("jwt", None)
+    sys.modules.setdefault(
+        "jwt",
+        SimpleNamespace(
+            encode=_stub_encode,
+            decode=_stub_decode,
+            ExpiredSignatureError=_StubExpiredSignatureError,
+            InvalidTokenError=_StubInvalidTokenError,
+        ),
+    )
+
+
+def test_backend_register_login_and_resume_flow(tmp_path, monkeypatch):
+    monkeypatch.setenv("JWT_SECRET", "test-secret")
+    backend_db = tmp_path / "backend.db"
+    monkeypatch.setenv("DATABASE_PATH", str(backend_db))
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    _install_stub_dependencies()
+    _reset_module("production_backend")
+    backend = importlib.import_module("production_backend")
+
+    with backend.app.app_context():
+        backend.init_db()
+
+    monkeypatch.setattr(
+        backend.openai_client.chat.completions,
+        "create",
+        lambda *args, **kwargs: _mock_chat_completion("Mock backend answer"),
+    )
+
+    client = backend.app.test_client()
+
+    register_response = client.post(
+        "/api/register",
+        json={"email": "test@example.com", "password": "secret123"},
+    )
+    assert register_response.status_code == 201
+
+    login_response = client.post(
+        "/api/login",
+        json={"email": "test@example.com", "password": "secret123"},
+    )
+    assert login_response.status_code == 200
+    token = login_response.get_json()["token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    ask_response = client.post(
+        "/api/ask",
+        json={"question": "Explain CAP theorem", "interview_mode": True},
+        headers=headers,
+    )
+    assert ask_response.status_code == 200
+    assert ask_response.get_json()["response"] == "Mock backend answer"
+
+    resume_text = "Experienced engineer" * 5
+    upload_response = client.post(
+        "/api/resume",
+        json={"resume_text": resume_text},
+        headers=headers,
+    )
+    assert upload_response.status_code == 200
+    assert upload_response.get_json()["length"] == len(resume_text)
+
+    fetch_response = client.get("/api/resume", headers=headers)
+    assert fetch_response.status_code == 200
+    assert fetch_response.get_json()["resume_text"] == resume_text
+
+
+def test_realtime_session_flow(tmp_path, monkeypatch):
+    monkeypatch.setenv("JWT_SECRET", "test-secret")
+    backend_db = tmp_path / "backend.db"
+    realtime_db = tmp_path / "realtime.db"
+    monkeypatch.setenv("DATABASE_PATH", str(backend_db))
+    monkeypatch.setenv("REALTIME_DATABASE_PATH", str(realtime_db))
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    _install_stub_dependencies()
+    _reset_module("production_backend")
+    backend = importlib.import_module("production_backend")
+    with backend.app.app_context():
+        backend.init_db()
+
+    monkeypatch.setattr(
+        backend.openai_client.chat.completions,
+        "create",
+        lambda *args, **kwargs: _mock_chat_completion("Mock backend answer"),
+    )
+
+    backend_client = backend.app.test_client()
+    backend_client.post(
+        "/api/register",
+        json={"email": "session@example.com", "password": "secret123"},
+    )
+    login_response = backend_client.post(
+        "/api/login",
+        json={"email": "session@example.com", "password": "secret123"},
+    )
+    token = login_response.get_json()["token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    _reset_module("production_realtime")
+    realtime = importlib.import_module("production_realtime")
+    with realtime.app.app_context():
+        realtime.init_db()
+
+    monkeypatch.setattr(
+        realtime,
+        "generate_ai_response",
+        lambda *args, **kwargs: "Mock real-time answer",
+    )
+
+    realtime_client = realtime.app.test_client()
+
+    session_response = realtime_client.post(
+        "/api/sessions",
+        json={"user_level": "IC6", "meeting_type": "technical_interview"},
+        headers=headers,
+    )
+    assert session_response.status_code == 201
+    session_id = session_response.get_json()["session_id"]
+
+    caption_response = realtime_client.post(
+        f"/api/sessions/{session_id}/captions",
+        json={
+            "text": "How would you design a scalable cache?",
+            "speaker": "interviewer",
+        },
+        headers=headers,
+    )
+    assert caption_response.status_code == 200
+    assert caption_response.get_json()["ai_response"]["answer"] == "Mock real-time answer"
+
+    answers_response = realtime_client.get(
+        f"/api/sessions/{session_id}/answers",
+        headers=headers,
+    )
+    assert answers_response.status_code == 200
+    answers = answers_response.get_json()["answers"]
+    assert len(answers) == 1
+    assert answers[0]["answer"] == "Mock real-time answer"
+    assert "scalable cache" in answers[0]["question"]
+
+    meeting_id = "rt-flow-meeting"
+    start_event = realtime_client.post(
+        "/api/meeting-events",
+        json={
+            "action": "meeting_started",
+            "data": {
+                "meetingId": meeting_id,
+                "participants": ["candidate", "interviewer"],
+            },
+        },
+        headers=headers,
+    )
+    assert start_event.status_code == 200
+    start_payload = start_event.get_json()
+    assert start_payload["ok"] is True
+    assert start_payload["result"]["status"] == "started"
+
+    caption_event = realtime_client.post(
+        "/api/meeting-events",
+        json={
+            "action": "caption_chunk",
+            "data": {
+                "meetingId": meeting_id,
+                "speaker": "interviewer",
+                "text": "How would you design caching tiers?",
+                "timestamp": 1_700_000_000,
+            },
+        },
+        headers=headers,
+    )
+    assert caption_event.status_code == 200
+    caption_payload = caption_event.get_json()["result"]
+    assert caption_payload["question_detected"] is True
+    assert caption_payload["question"]["question"].endswith("?")
+
+    end_event = realtime_client.post(
+        "/api/meeting-events",
+        json={
+            "action": "meeting_ended",
+            "data": {"meetingId": meeting_id},
+        },
+        headers=headers,
+    )
+    assert end_event.status_code == 200
+    end_payload = end_event.get_json()["result"]
+    assert end_payload["status"] == "ended"
+    assert end_payload["summary"]["meeting_id"] == meeting_id
+    assert end_payload["pending_questions"]
+
+
+def test_meeting_event_router_end_to_end(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    _install_stub_dependencies()
+    for module_name in [
+        "backend.meeting_events",
+        "backend.app_factory",
+        "app.meeting_intelligence",
+    ]:
+        _reset_module(module_name)
+
+    app_factory = importlib.import_module("backend.app_factory")
+    meeting_app = app_factory.create_app()
+    client = meeting_app.test_client()
+
+    start_resp = client.post(
+        "/api/meeting-events",
+        json={
+            "action": "meeting_started",
+            "data": {
+                "meetingId": "mtg-123",
+                "sessionId": "sess-1",
+                "participants": ["candidate", "interviewer"],
+            },
+        },
+    )
+    assert start_resp.status_code == 200
+    start_payload = start_resp.get_json()
+    assert start_payload["ok"] is True
+    assert start_payload["result"]["status"] == "started"
+
+    caption_resp = client.post(
+        "/api/meeting-events",
+        json={
+            "action": "caption_chunk",
+            "data": {
+                "meetingId": "mtg-123",
+                "text": "How would you design caching layers?",
+                "speaker": "interviewer",
+                "timestamp": 1_694_000_000,
+            },
+        },
+    )
+    assert caption_resp.status_code == 200
+    caption_payload = caption_resp.get_json()
+    assert caption_payload["result"]["question_detected"] is True
+    detected_questions = caption_payload["result"]["analysis"]["questions_detected"]
+    assert detected_questions and "caching layers" in detected_questions[0]
+
+    end_resp = client.post(
+        "/api/meeting-events",
+        json={
+            "action": "meeting_ended",
+            "data": {"meetingId": "mtg-123"},
+        },
+    )
+    assert end_resp.status_code == 200
+    end_payload = end_resp.get_json()
+    assert end_payload["result"]["status"] == "ended"
+    summary = end_payload["result"]["summary"]
+    assert summary["meeting_id"] == "mtg-123"
+    assert summary["summary"].startswith("Stub summary")
+    pending = end_payload["result"]["pending_questions"]
+    assert pending and "caching layers" in pending[0]["question"]


### PR DESCRIPTION
## Summary
- expose meeting event ingestion in the backend server so capture clients benefit from question detection and summaries
- hook the production realtime service into the shared MeetingEventRouter implementation
- extend the realtime service test to cover the end-to-end meeting event lifecycle via the public API

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e674c746a48323881945ea0e58c4a6