### PR TITLE
Add Jira integration with sync and search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,7 @@ demo_*.py
 setup_*.sh
 data/*.db
 !tests/test_meeting_intelligence.py
+!tests/test_jira_integration.py
 
 # Internal documentation
 INTERNAL_README.md

--- a/backend/db/migrations/versions/20240315000000_jira_tables.py
+++ b/backend/db/migrations/versions/20240315000000_jira_tables.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "20240315000000"
+down_revision = "20240223000000"
+branch_labels = None
+depends_on = None
+
+
+def _jsonb_type():
+    jsonb = postgresql.JSONB(astext_type=sa.Text())
+    return jsonb.with_variant(sa.JSON(), "sqlite")
+
+
+def _text_array():
+    array = postgresql.ARRAY(sa.Text())
+    return array.with_variant(sa.JSON(), "sqlite")
+
+
+def upgrade() -> None:
+    jsonb = _jsonb_type()
+    text_array = _text_array()
+
+    op.create_table(
+        "jira_connection",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("cloud_base_url", sa.Text(), nullable=False),
+        sa.Column("client_id", sa.Text(), nullable=False),
+        sa.Column("token_type", sa.Text(), nullable=True),
+        sa.Column("access_token", sa.Text(), nullable=False),
+        sa.Column("refresh_token", sa.Text(), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("scopes", text_array, nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=True),
+    )
+
+    op.create_table(
+        "jira_project_config",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("connection_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("jira_connection.id"), nullable=False),
+        sa.Column("project_keys", text_array, nullable=False),
+        sa.Column("board_ids", text_array, nullable=True),
+        sa.Column("default_jql", sa.Text(), nullable=True),
+        sa.Column("last_sync_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+    op.create_table(
+        "jira_issue",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("connection_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("jira_connection.id"), nullable=False),
+        sa.Column("project_key", sa.Text(), nullable=False),
+        sa.Column("issue_key", sa.Text(), nullable=False, unique=True),
+        sa.Column("summary", sa.Text(), nullable=True),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("status", sa.Text(), nullable=True),
+        sa.Column("priority", sa.Text(), nullable=True),
+        sa.Column("assignee", sa.Text(), nullable=True),
+        sa.Column("reporter", sa.Text(), nullable=True),
+        sa.Column("labels", text_array, nullable=True),
+        sa.Column("epic_key", sa.Text(), nullable=True),
+        sa.Column("sprint", sa.Text(), nullable=True),
+        sa.Column("updated", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("url", sa.Text(), nullable=True),
+        sa.Column("raw", jsonb, nullable=True),
+        sa.Column("indexed_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("jira_issue")
+    op.drop_table("jira_project_config")
+    op.drop_table("jira_connection")

--- a/backend/db/migrations/versions/20240315000000_jira_tables.py
+++ b/backend/db/migrations/versions/20240315000000_jira_tables.py
@@ -55,7 +55,7 @@ def upgrade() -> None:
         sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
         sa.Column("connection_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("jira_connection.id"), nullable=False),
         sa.Column("project_key", sa.Text(), nullable=False),
-        sa.Column("issue_key", sa.Text(), nullable=False, unique=True),
+        sa.Column("issue_key", sa.Text(), nullable=False),
         sa.Column("summary", sa.Text(), nullable=True),
         sa.Column("description", sa.Text(), nullable=True),
         sa.Column("status", sa.Text(), nullable=True),
@@ -69,6 +69,7 @@ def upgrade() -> None:
         sa.Column("url", sa.Text(), nullable=True),
         sa.Column("raw", jsonb, nullable=True),
         sa.Column("indexed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.UniqueConstraint("connection_id", "issue_key", name="uq_jira_issue_connection_issue"),
     )
 
 

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime
 
-from sqlalchemy import Column, DateTime, ForeignKey, Integer, Numeric, String, Text
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, Numeric, String, Text, UniqueConstraint
 from sqlalchemy.dialects.postgresql import ARRAY, JSONB, UUID
 from sqlalchemy.types import JSON, TypeDecorator
 
@@ -120,11 +120,12 @@ class JiraProjectConfig(Base):
 
 class JiraIssue(Base):
     __tablename__ = "jira_issue"
+    __table_args__ = (UniqueConstraint("connection_id", "issue_key", name="uq_jira_issue_connection_issue"),)
 
     id = Column(UUID_TYPE, primary_key=True, default=uuid.uuid4)
     connection_id = Column(UUID_TYPE, ForeignKey("jira_connection.id"), nullable=False)
     project_key = Column(Text, nullable=False)
-    issue_key = Column(Text, unique=True, nullable=False)
+    issue_key = Column(Text, nullable=False)
     summary = Column(Text, nullable=True)
     description = Column(Text, nullable=True)
     status = Column(Text, nullable=True)

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -4,10 +4,34 @@ import uuid
 from datetime import datetime
 
 from sqlalchemy import Column, DateTime, ForeignKey, Integer, Numeric, String, Text
-from sqlalchemy.dialects.postgresql import JSONB, UUID
-from sqlalchemy.types import JSON
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB, UUID
+from sqlalchemy.types import JSON, TypeDecorator
 
 from .base import Base
+
+class GUID(TypeDecorator):
+    impl = UUID
+    cache_ok = True
+
+    def load_dialect_impl(self, dialect):
+        if dialect.name == "postgresql":
+            return dialect.type_descriptor(UUID(as_uuid=True))
+        return dialect.type_descriptor(String(36))
+
+    def process_bind_param(self, value, dialect):
+        if value is None:
+            return value
+        if isinstance(value, uuid.UUID):
+            return value if dialect.name == "postgresql" else str(value)
+        return str(uuid.UUID(str(value)))
+
+    def process_result_value(self, value, dialect):
+        if value is None:
+            return value
+        return value if isinstance(value, uuid.UUID) else uuid.UUID(str(value))
+
+
+UUID_TYPE = GUID()
 
 
 def _jsonb_column(name: str):
@@ -15,24 +39,29 @@ def _jsonb_column(name: str):
     return Column(name, jsonb_type)
 
 
+def _text_array_column(name: str, nullable: bool = True):
+    array_type = ARRAY(Text()).with_variant(JSON(), "sqlite")
+    return Column(name, array_type, nullable=nullable)
+
+
 class Meeting(Base):
     __tablename__ = "meeting"
 
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    session_id = Column(UUID(as_uuid=True), unique=True, nullable=False)
+    id = Column(UUID_TYPE, primary_key=True, default=uuid.uuid4)
+    session_id = Column(UUID_TYPE, unique=True, nullable=False)
     title = Column(Text)
     provider = Column(String(100))
     started_at = Column(DateTime(timezone=True), nullable=True)
     ended_at = Column(DateTime(timezone=True), nullable=True)
     participants = _jsonb_column("participants")
-    org_id = Column(UUID(as_uuid=True), nullable=True)
+    org_id = Column(UUID_TYPE, nullable=True)
 
 
 class TranscriptSegment(Base):
     __tablename__ = "transcript_segment"
 
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    meeting_id = Column(UUID(as_uuid=True), ForeignKey("meeting.id"), nullable=False)
+    id = Column(UUID_TYPE, primary_key=True, default=uuid.uuid4)
+    meeting_id = Column(UUID_TYPE, ForeignKey("meeting.id"), nullable=False)
     ts_start_ms = Column(Integer, nullable=False)
     ts_end_ms = Column(Integer, nullable=False)
     speaker = Column(String(255))
@@ -42,7 +71,7 @@ class TranscriptSegment(Base):
 class MeetingSummary(Base):
     __tablename__ = "meeting_summary"
 
-    meeting_id = Column(UUID(as_uuid=True), ForeignKey("meeting.id"), primary_key=True)
+    meeting_id = Column(UUID_TYPE, ForeignKey("meeting.id"), primary_key=True)
     bullets = _jsonb_column("bullets")
     decisions = _jsonb_column("decisions")
     risks = _jsonb_column("risks")
@@ -52,10 +81,60 @@ class MeetingSummary(Base):
 class ActionItem(Base):
     __tablename__ = "action_item"
 
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    meeting_id = Column(UUID(as_uuid=True), ForeignKey("meeting.id"), nullable=False)
+    id = Column(UUID_TYPE, primary_key=True, default=uuid.uuid4)
+    meeting_id = Column(UUID_TYPE, ForeignKey("meeting.id"), nullable=False)
     title = Column(Text, nullable=False)
     assignee = Column(String(255))
     due_hint = Column(String(255))
     confidence = Column(Numeric)
-    source_segment = Column(UUID(as_uuid=True), ForeignKey("transcript_segment.id"), nullable=True)
+    source_segment = Column(UUID_TYPE, ForeignKey("transcript_segment.id"), nullable=True)
+
+
+class JiraConnection(Base):
+    __tablename__ = "jira_connection"
+
+    id = Column(UUID_TYPE, primary_key=True, default=uuid.uuid4)
+    org_id = Column(UUID_TYPE, nullable=False)
+    user_id = Column(UUID_TYPE, nullable=False)
+    cloud_base_url = Column(Text, nullable=False)
+    client_id = Column(Text, nullable=False)
+    token_type = Column(Text, nullable=True)
+    access_token = Column(Text, nullable=False)
+    refresh_token = Column(Text, nullable=False)
+    expires_at = Column(DateTime(timezone=True), nullable=True)
+    scopes = _text_array_column("scopes", nullable=True)
+    created_at = Column(DateTime(timezone=True), default=datetime.utcnow)
+
+
+class JiraProjectConfig(Base):
+    __tablename__ = "jira_project_config"
+
+    id = Column(UUID_TYPE, primary_key=True, default=uuid.uuid4)
+    org_id = Column(UUID_TYPE, nullable=False)
+    connection_id = Column(UUID_TYPE, ForeignKey("jira_connection.id"), nullable=False)
+    project_keys = _text_array_column("project_keys", nullable=False)
+    board_ids = _text_array_column("board_ids", nullable=True)
+    default_jql = Column(Text, nullable=True)
+    last_sync_at = Column(DateTime(timezone=True), nullable=True)
+
+
+class JiraIssue(Base):
+    __tablename__ = "jira_issue"
+
+    id = Column(UUID_TYPE, primary_key=True, default=uuid.uuid4)
+    connection_id = Column(UUID_TYPE, ForeignKey("jira_connection.id"), nullable=False)
+    project_key = Column(Text, nullable=False)
+    issue_key = Column(Text, unique=True, nullable=False)
+    summary = Column(Text, nullable=True)
+    description = Column(Text, nullable=True)
+    status = Column(Text, nullable=True)
+    priority = Column(Text, nullable=True)
+    assignee = Column(Text, nullable=True)
+    reporter = Column(Text, nullable=True)
+    labels = _text_array_column("labels", nullable=True)
+    epic_key = Column(Text, nullable=True)
+    sprint = Column(Text, nullable=True)
+    updated = Column(DateTime(timezone=True), nullable=True)
+    url = Column(Text, nullable=True)
+    raw = _jsonb_column("raw")
+    indexed_at = Column(DateTime(timezone=True), nullable=True)

--- a/backend/jira_api.py
+++ b/backend/jira_api.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime
+from typing import Optional
+
+from flask import Blueprint, jsonify, request
+
+from backend.jira_integration import integration_service
+
+
+bp = Blueprint("jira_integration", __name__)
+
+
+def _parse_uuid(value: Optional[str], env_var: str) -> uuid.UUID:
+    if value:
+        try:
+            return uuid.UUID(value)
+        except ValueError:
+            raise ValueError(f"Invalid UUID: {value}")
+    env_default = os.getenv(env_var)
+    if env_default:
+        return uuid.UUID(env_default)
+    # Deterministic fallback
+    return uuid.uuid5(uuid.NAMESPACE_DNS, env_var)
+
+
+def _resolve_org_id() -> uuid.UUID:
+    header = request.headers.get("X-Org-Id") or request.args.get("org_id")
+    return _parse_uuid(header, "DEFAULT_ORG_ID")
+
+
+def _resolve_user_id() -> uuid.UUID:
+    header = request.headers.get("X-User-Id") or request.args.get("user_id")
+    return _parse_uuid(header, "DEFAULT_USER_ID")
+
+
+def _resolve_assignee(value: Optional[str]) -> Optional[str]:
+    if not value:
+        return None
+    if value.lower() != "me":
+        return value
+    return request.headers.get("X-User-Name") or request.headers.get("X-User-Email")
+
+
+@bp.route("/api/integrations/jira/oauth/start", methods=["POST"])
+def jira_oauth_start():
+    org_id = _resolve_org_id()
+    user_id = _resolve_user_id()
+    payload = request.get_json(silent=True) or {}
+    scopes = payload.get("scopes")
+    if scopes and not isinstance(scopes, list):
+        return jsonify({"error": "scopes must be an array"}), 400
+    result = integration_service.start_oauth(org_id, user_id, scopes=scopes)
+    return jsonify(result)
+
+
+@bp.route("/api/integrations/jira/oauth/callback", methods=["GET"])
+def jira_oauth_callback():
+    code = request.args.get("code")
+    state = request.args.get("state")
+    if not code:
+        return jsonify({"error": "Missing authorization code"}), 400
+    try:
+        result = integration_service.complete_oauth(code, state=state)
+    except Exception as exc:  # pragma: no cover - error path
+        return jsonify({"error": str(exc)}), 400
+    return jsonify(result)
+
+
+@bp.route("/api/integrations/jira/config", methods=["POST"])
+def jira_config_update():
+    org_id = _resolve_org_id()
+    user_id = _resolve_user_id()
+    payload = request.get_json(force=True)
+    project_keys = payload.get("project_keys") or []
+    if not isinstance(project_keys, list) or not project_keys:
+        return jsonify({"error": "project_keys must be a non-empty array"}), 400
+    board_ids = payload.get("board_ids") or []
+    default_jql = payload.get("default_jql")
+    result = integration_service.update_project_config(
+        org_id,
+        user_id,
+        project_keys=project_keys,
+        board_ids=board_ids,
+        default_jql=default_jql,
+    )
+    return jsonify(result)
+
+
+@bp.route("/api/integrations/jira/status", methods=["GET"])
+def jira_status():
+    org_id = _resolve_org_id()
+    result = integration_service.get_status(org_id)
+    return jsonify(result)
+
+
+@bp.route("/api/integrations/jira/sync", methods=["POST"])
+def jira_sync():
+    org_id = _resolve_org_id()
+    payload = request.get_json(silent=True) or {}
+    if payload.get("run_now"):
+        result = integration_service.sync_now(org_id)
+        return jsonify({"fetched": result.fetched, "updated": result.updated, "indexed": result.indexed})
+    result = integration_service.trigger_sync(org_id)
+    return jsonify(result)
+
+
+@bp.route("/api/jira/tasks", methods=["GET"])
+def jira_tasks():
+    org_id = _resolve_org_id()
+    assignee = _resolve_assignee(request.args.get("assignee"))
+    status = request.args.get("status")
+    project = request.args.get("project")
+    updated_since_raw = request.args.get("updated_since")
+    updated_since = None
+    if updated_since_raw:
+        try:
+            updated_since = datetime.fromisoformat(updated_since_raw)
+        except ValueError:
+            return jsonify({"error": "Invalid updated_since timestamp"}), 400
+    tasks = integration_service.list_tasks(
+        org_id,
+        assignee=assignee,
+        status=status,
+        project=project,
+        updated_since=updated_since,
+    )
+    return jsonify(tasks)
+
+
+@bp.route("/api/jira/search", methods=["GET"])
+def jira_search():
+    org_id = _resolve_org_id()
+    query = request.args.get("q", "")
+    project = request.args.get("project")
+    try:
+        top_k = int(request.args.get("top_k", "10"))
+    except ValueError:
+        return jsonify({"error": "Invalid top_k"}), 400
+    results = integration_service.search(org_id, query, project=project, top_k=top_k)
+    return jsonify(results)
+
+
+@bp.route("/api/jira/issues/<issue_key>", methods=["GET"])
+def jira_issue_detail(issue_key: str):
+    org_id = _resolve_org_id()
+    result = integration_service.get_issue(org_id, issue_key)
+    if not result:
+        return jsonify({"error": "Not Found"}), 404
+    return jsonify(result)
+
+
+__all__ = ["bp"]

--- a/backend/jira_api.py
+++ b/backend/jira_api.py
@@ -64,7 +64,7 @@ def jira_oauth_callback():
         return jsonify({"error": "Missing authorization code"}), 400
     try:
         result = integration_service.complete_oauth(code, state=state)
-    except Exception as exc:  # pragma: no cover - error path
+    except (ValueError, RuntimeError) as exc:  # pragma: no cover - error path
         return jsonify({"error": str(exc)}), 400
     return jsonify(result)
 

--- a/backend/jira_integration.py
+++ b/backend/jira_integration.py
@@ -1,0 +1,682 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Tuple
+
+import requests
+from cryptography.fernet import Fernet
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from backend.db.base import session_scope
+from backend.db.models import JiraConnection, JiraIssue, JiraProjectConfig
+from backend.jira_vector_store import JiraVectorStore
+
+
+JIRA_OAUTH_AUTHORIZE_URL = "https://auth.atlassian.com/authorize"
+JIRA_OAUTH_TOKEN_URL = "https://auth.atlassian.com/oauth/token"
+ACCESSIBLE_RESOURCES_URL = "https://api.atlassian.com/oauth/token/accessible-resources"
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _default_org_id() -> uuid.UUID:
+    raw = os.getenv("DEFAULT_ORG_ID", "00000000-0000-4000-8000-000000000000")
+    return uuid.UUID(raw)
+
+
+def _default_user_id() -> uuid.UUID:
+    raw = os.getenv("DEFAULT_USER_ID", "00000000-0000-4000-8000-000000000001")
+    return uuid.UUID(raw)
+
+
+def _fernet_key() -> bytes:
+    raw = os.getenv("JIRA_ENCRYPTION_KEY")
+    if raw:
+        try:
+            # Allow passing pre-encoded key
+            Fernet(raw.encode())
+            return raw.encode()
+        except Exception:
+            pass
+        digest = hashlib.sha256(raw.encode("utf-8")).digest()
+        return base64.urlsafe_b64encode(digest)
+    digest = hashlib.sha256(b"mentor-app-jira-secret").digest()
+    return base64.urlsafe_b64encode(digest)
+
+
+_FERNET = Fernet(_fernet_key())
+
+
+def _encrypt(value: str | None) -> str:
+    if value is None:
+        return ""
+    return _FERNET.encrypt(value.encode("utf-8")).decode("utf-8")
+
+
+def _decrypt(value: str | None) -> str:
+    if not value:
+        return ""
+    return _FERNET.decrypt(value.encode("utf-8")).decode("utf-8")
+
+
+def _parse_datetime(value: str | None) -> Optional[datetime]:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _format_datetime(dt: Optional[datetime]) -> Optional[str]:
+    if not dt:
+        return None
+    return dt.astimezone(timezone.utc).isoformat()
+
+
+def _load_mock_fixture(name: str) -> Dict[str, object]:
+    base = Path(__file__).resolve().parents[1] / "tests" / "fixtures" / "jira"
+    path = base / name
+    if not path.exists():
+        return {}
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+@dataclass
+class JiraSyncResult:
+    fetched: int
+    updated: int
+    indexed: int
+
+
+class JiraIntegrationService:
+    def __init__(self) -> None:
+        self._vector_store = JiraVectorStore()
+        self._state_cache: Dict[str, Tuple[uuid.UUID, uuid.UUID]] = {}
+        self._sync_lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    # OAuth
+    # ------------------------------------------------------------------
+    def start_oauth(self, org_id: uuid.UUID, user_id: uuid.UUID, scopes: Optional[List[str]] = None) -> Dict[str, str]:
+        state = uuid.uuid4().hex
+        self._state_cache[state] = (org_id, user_id)
+
+        if os.getenv("MOCK_JIRA", "false").lower() == "true":
+            return {"auth_url": "mock://jira/oauth", "state": state}
+
+        client_id = os.getenv("JIRA_CLIENT_ID")
+        redirect_uri = os.getenv("JIRA_REDIRECT_URI")
+        if not client_id or not redirect_uri:
+            raise RuntimeError("Missing JIRA_CLIENT_ID or JIRA_REDIRECT_URI environment variables")
+
+        scope_param = " ".join(scopes or os.getenv("JIRA_SCOPES", "offline_access read:jira-work manage:jira-project").split())
+        params = {
+            "audience": "api.atlassian.com",
+            "client_id": client_id,
+            "scope": scope_param,
+            "redirect_uri": redirect_uri,
+            "state": state,
+            "response_type": "code",
+            "prompt": "consent",
+        }
+        query = "&".join(f"{key}={requests.utils.quote(str(value))}" for key, value in params.items())
+        return {"auth_url": f"{JIRA_OAUTH_AUTHORIZE_URL}?{query}", "state": state}
+
+    def complete_oauth(self, code: str, state: Optional[str] = None) -> Dict[str, object]:
+        org_id, user_id = self._state_cache.pop(state or "", (_default_org_id(), _default_user_id()))
+        mock_mode = os.getenv("MOCK_JIRA", "false").lower() == "true"
+
+        with session_scope() as session:
+            existing = self._get_connection(session, org_id)
+            if mock_mode:
+                connection = self._create_or_update_mock_connection(session, existing, org_id, user_id)
+            else:
+                connection = self._exchange_code_for_tokens(session, existing, org_id, user_id, code)
+
+        return {
+            "connected": True,
+            "connection_id": str(connection.id),
+            "org_id": str(connection.org_id),
+            "scopes": connection.scopes or [],
+        }
+
+    def _create_or_update_mock_connection(
+        self,
+        session: Session,
+        existing: Optional[JiraConnection],
+        org_id: uuid.UUID,
+        user_id: uuid.UUID,
+    ) -> JiraConnection:
+        base_url = os.getenv("JIRA_CLOUD_BASE_URL", "https://mock-jira.example.com")
+        access_token = _encrypt("mock-access-token")
+        refresh_token = _encrypt("mock-refresh-token")
+        if existing:
+            existing.access_token = access_token
+            existing.refresh_token = refresh_token
+            existing.expires_at = _now() + timedelta(hours=1)
+            existing.scopes = ["read:jira-work", "offline_access"]
+            session.add(existing)
+            session.flush()
+            return existing
+
+        connection = JiraConnection(
+            org_id=org_id,
+            user_id=user_id,
+            cloud_base_url=base_url,
+            client_id="mock-client",
+            token_type="Bearer",
+            access_token=access_token,
+            refresh_token=refresh_token,
+            expires_at=_now() + timedelta(hours=1),
+            scopes=["read:jira-work", "offline_access"],
+        )
+        session.add(connection)
+        session.flush()
+        return connection
+
+    def _exchange_code_for_tokens(
+        self,
+        session: Session,
+        existing: Optional[JiraConnection],
+        org_id: uuid.UUID,
+        user_id: uuid.UUID,
+        code: str,
+    ) -> JiraConnection:
+        client_id = os.getenv("JIRA_CLIENT_ID")
+        client_secret = os.getenv("JIRA_CLIENT_SECRET")
+        redirect_uri = os.getenv("JIRA_REDIRECT_URI")
+        if not client_id or not client_secret or not redirect_uri:
+            raise RuntimeError("Missing JIRA OAuth configuration")
+
+        payload = {
+            "grant_type": "authorization_code",
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "code": code,
+            "redirect_uri": redirect_uri,
+        }
+        response = requests.post(JIRA_OAUTH_TOKEN_URL, json=payload, timeout=30)
+        response.raise_for_status()
+        data = response.json()
+
+        access_token = data.get("access_token")
+        refresh_token = data.get("refresh_token")
+        expires_in = data.get("expires_in", 3600)
+        token_type = data.get("token_type", "Bearer")
+        scope_raw = data.get("scope", "")
+        scopes = [scope for scope in scope_raw.split() if scope]
+
+        headers = {"Authorization": f"Bearer {access_token}", "Accept": "application/json"}
+        resources_resp = requests.get(ACCESSIBLE_RESOURCES_URL, headers=headers, timeout=30)
+        resources_resp.raise_for_status()
+        resources = resources_resp.json() or []
+        cloud_base_url = resources[0].get("url") if resources else os.getenv("JIRA_CLOUD_BASE_URL")
+        if not cloud_base_url:
+            raise RuntimeError("Unable to resolve Jira cloud base URL")
+
+        expires_at = _now() + timedelta(seconds=int(expires_in))
+        encrypted_access = _encrypt(access_token)
+        encrypted_refresh = _encrypt(refresh_token)
+
+        if existing:
+            existing.access_token = encrypted_access
+            existing.refresh_token = encrypted_refresh
+            existing.expires_at = expires_at
+            existing.token_type = token_type
+            existing.scopes = scopes
+            existing.cloud_base_url = cloud_base_url
+            session.add(existing)
+            session.flush()
+            return existing
+
+        connection = JiraConnection(
+            org_id=org_id,
+            user_id=user_id,
+            cloud_base_url=cloud_base_url,
+            client_id=client_id,
+            token_type=token_type,
+            access_token=encrypted_access,
+            refresh_token=encrypted_refresh,
+            expires_at=expires_at,
+            scopes=scopes,
+        )
+        session.add(connection)
+        session.flush()
+        return connection
+
+    # ------------------------------------------------------------------
+    # Configuration & Status
+    # ------------------------------------------------------------------
+    def update_project_config(
+        self,
+        org_id: uuid.UUID,
+        user_id: uuid.UUID,
+        project_keys: List[str],
+        board_ids: Optional[List[str]] = None,
+        default_jql: Optional[str] = None,
+    ) -> Dict[str, object]:
+        with session_scope() as session:
+            connection = self._get_connection(session, org_id)
+            if not connection:
+                raise RuntimeError("Jira connection not found for organization")
+
+            config = (
+                session.execute(
+                    select(JiraProjectConfig).where(
+                        JiraProjectConfig.org_id == org_id,
+                        JiraProjectConfig.connection_id == connection.id,
+                    )
+                )
+                .scalars()
+                .first()
+            )
+            if config:
+                config.project_keys = project_keys
+                config.board_ids = board_ids or []
+                config.default_jql = default_jql
+                session.add(config)
+                session.flush()
+            else:
+                config = JiraProjectConfig(
+                    org_id=org_id,
+                    connection_id=connection.id,
+                    project_keys=project_keys,
+                    board_ids=board_ids or [],
+                    default_jql=default_jql,
+                )
+                session.add(config)
+                session.flush()
+
+            return {
+                "config_id": str(config.id),
+                "project_keys": config.project_keys,
+                "board_ids": config.board_ids or [],
+                "default_jql": config.default_jql,
+            }
+
+    def get_status(self, org_id: uuid.UUID) -> Dict[str, object]:
+        with session_scope() as session:
+            connection = self._get_connection(session, org_id)
+            if not connection:
+                return {"connected": False, "projects": [], "scopes": []}
+
+            config = (
+                session.execute(
+                    select(JiraProjectConfig).where(
+                        JiraProjectConfig.connection_id == connection.id,
+                        JiraProjectConfig.org_id == org_id,
+                    )
+                )
+                .scalars()
+                .first()
+            )
+            projects = config.project_keys if config else []
+            last_sync = _format_datetime(config.last_sync_at if config else None)
+
+            return {
+                "connected": True,
+                "last_sync_at": last_sync,
+                "projects": projects,
+                "scopes": connection.scopes or [],
+            }
+
+    # ------------------------------------------------------------------
+    # Sync
+    # ------------------------------------------------------------------
+    def trigger_sync(self, org_id: uuid.UUID) -> Dict[str, object]:
+        thread = threading.Thread(target=self._sync_worker, args=(org_id,), daemon=True)
+        thread.start()
+        return {"enqueued": True}
+
+    def _sync_worker(self, org_id: uuid.UUID) -> None:
+        with self._sync_lock:
+            try:
+                self.sync_now(org_id)
+            except Exception:
+                # swallow exceptions to avoid crashing the worker thread
+                pass
+
+    def sync_now(self, org_id: uuid.UUID) -> JiraSyncResult:
+        mock_mode = os.getenv("MOCK_JIRA", "false").lower() == "true"
+        fetched = 0
+        updated = 0
+        indexed = 0
+
+        with session_scope() as session:
+            connection = self._get_connection(session, org_id)
+            if not connection:
+                return JiraSyncResult(fetched=0, updated=0, indexed=0)
+
+            config = (
+                session.execute(
+                    select(JiraProjectConfig).where(
+                        JiraProjectConfig.connection_id == connection.id,
+                        JiraProjectConfig.org_id == org_id,
+                    )
+                )
+                .scalars()
+                .first()
+            )
+            if not config or not config.project_keys:
+                return JiraSyncResult(fetched=0, updated=0, indexed=0)
+
+            since = (config.last_sync_at or (_now() - timedelta(days=30))) - timedelta(minutes=5)
+            since_str = since.strftime("%Y-%m-%d %H:%M")
+            base_jql = config.default_jql or f"project in ({','.join(config.project_keys)})"
+            jql = f"({base_jql}) AND updated >= \"{since_str}\""
+
+            access_token = self._ensure_access_token(session, connection)
+
+            issue_payloads = list(self._fetch_issues(connection, access_token, jql, mock_mode=mock_mode))
+            fetched = len(issue_payloads)
+            now = _now()
+
+            indexed_payload: List[Tuple[str, str, Dict[str, str]]] = []
+            for payload in issue_payloads:
+                issue, created = self._upsert_issue(session, connection, payload, now)
+                if created:
+                    updated += 1
+                doc = self._compose_index_document(issue)
+                metadata = {
+                    "summary": issue.summary or "",
+                    "status": issue.status or "",
+                    "assignee": issue.assignee or "",
+                    "project": issue.project_key or "",
+                }
+                indexed_payload.append((issue.issue_key, doc, metadata))
+            config.last_sync_at = now
+            session.add(config)
+            session.flush()
+
+        for issue_key, document, metadata in indexed_payload:
+            self._vector_store.index_issue(issue_key, document, metadata)
+            indexed += 1
+
+        return JiraSyncResult(fetched=fetched, updated=updated, indexed=indexed)
+
+    def _ensure_access_token(self, session: Session, connection: JiraConnection) -> str:
+        expires_at = connection.expires_at or (_now() - timedelta(seconds=1))
+        if expires_at.tzinfo is None:
+            expires_at = expires_at.replace(tzinfo=timezone.utc)
+        if expires_at > _now() + timedelta(seconds=30):
+            return _decrypt(connection.access_token)
+
+        if os.getenv("MOCK_JIRA", "false").lower() == "true":
+            connection.access_token = _encrypt("mock-access-token")
+            connection.expires_at = _now() + timedelta(hours=1)
+            session.add(connection)
+            session.flush()
+            return "mock-access-token"
+
+        client_id = connection.client_id
+        client_secret = os.getenv("JIRA_CLIENT_SECRET")
+        refresh_token = _decrypt(connection.refresh_token)
+        if not client_id or not client_secret:
+            raise RuntimeError("Missing client credentials for Jira refresh")
+
+        payload = {
+            "grant_type": "refresh_token",
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "refresh_token": refresh_token,
+        }
+        response = requests.post(JIRA_OAUTH_TOKEN_URL, json=payload, timeout=30)
+        response.raise_for_status()
+        data = response.json()
+        access_token = data.get("access_token")
+        expires_in = data.get("expires_in", 3600)
+
+        connection.access_token = _encrypt(access_token)
+        connection.expires_at = _now() + timedelta(seconds=int(expires_in))
+        session.add(connection)
+        session.flush()
+        return access_token
+
+    def _fetch_issues(
+        self,
+        connection: JiraConnection,
+        access_token: str,
+        jql: str,
+        mock_mode: bool = False,
+        max_results: int = 100,
+    ) -> Iterable[Dict[str, object]]:
+        if mock_mode:
+            data = _load_mock_fixture("issues.json")
+            issues = data.get("issues", []) if isinstance(data, dict) else []
+            for item in issues:
+                yield item
+            return
+
+        base_url = connection.cloud_base_url.rstrip("/")
+        url = f"{base_url}/rest/api/3/search"
+        start_at = 0
+        total = None
+        backoff = 1
+
+        while total is None or start_at < total:
+            params = {"jql": jql, "maxResults": max_results, "startAt": start_at}
+            headers = {"Authorization": f"Bearer {access_token}", "Accept": "application/json"}
+            response = requests.get(url, headers=headers, params=params, timeout=60)
+            if response.status_code == 429:
+                retry_after = int(response.headers.get("Retry-After", backoff))
+                time.sleep(min(retry_after, 30))
+                backoff = min(backoff * 2, 60)
+                continue
+            response.raise_for_status()
+            data = response.json()
+            issues = data.get("issues", [])
+            total = data.get("total", start_at + len(issues))
+            for issue in issues:
+                yield issue
+            fetched_count = len(issues)
+            if fetched_count == 0:
+                break
+            start_at += fetched_count
+
+    def _upsert_issue(
+        self,
+        session: Session,
+        connection: JiraConnection,
+        payload: Dict[str, object],
+        indexed_at: datetime,
+    ) -> Tuple[JiraIssue, bool]:
+        issue_key = str(payload.get("key"))
+        fields = payload.get("fields", {}) if isinstance(payload.get("fields"), dict) else {}
+        project = fields.get("project", {}) if isinstance(fields.get("project"), dict) else {}
+        project_key = project.get("key") or issue_key.split("-")[0]
+        summary = fields.get("summary")
+        description_raw = fields.get("description")
+        description = description_raw if isinstance(description_raw, str) else json.dumps(description_raw or {}) if description_raw else None
+        status = (fields.get("status") or {}).get("name") if isinstance(fields.get("status"), dict) else None
+        priority = (fields.get("priority") or {}).get("name") if isinstance(fields.get("priority"), dict) else None
+        assignee = (fields.get("assignee") or {}).get("displayName") if isinstance(fields.get("assignee"), dict) else None
+        reporter = (fields.get("reporter") or {}).get("displayName") if isinstance(fields.get("reporter"), dict) else None
+        labels = fields.get("labels") if isinstance(fields.get("labels"), list) else []
+        epic = (fields.get("epic") or {}).get("key") if isinstance(fields.get("epic"), dict) else None
+        sprint = None
+        if isinstance(fields.get("sprint"), dict):
+            sprint = fields.get("sprint", {}).get("name")
+        elif isinstance(fields.get("sprint"), list) and fields.get("sprint"):
+            sprint = fields.get("sprint")[0].get("name")
+        updated = _parse_datetime(fields.get("updated"))
+        url = f"{connection.cloud_base_url.rstrip('/')}/browse/{issue_key}"
+
+        issue = (
+            session.execute(select(JiraIssue).where(JiraIssue.issue_key == issue_key))
+            .scalars()
+            .first()
+        )
+        created = False
+        if issue:
+            issue.summary = summary
+            issue.description = description
+            issue.status = status
+            issue.priority = priority
+            issue.assignee = assignee
+            issue.reporter = reporter
+            issue.labels = labels
+            issue.epic_key = epic
+            issue.sprint = sprint
+            issue.updated = updated
+            issue.url = url
+            issue.raw = payload
+            issue.indexed_at = indexed_at
+        else:
+            issue = JiraIssue(
+                connection_id=connection.id,
+                project_key=project_key,
+                issue_key=issue_key,
+                summary=summary,
+                description=description,
+                status=status,
+                priority=priority,
+                assignee=assignee,
+                reporter=reporter,
+                labels=labels,
+                epic_key=epic,
+                sprint=sprint,
+                updated=updated,
+                url=url,
+                raw=payload,
+                indexed_at=indexed_at,
+            )
+            session.add(issue)
+            created = True
+        session.flush()
+        return issue, created
+
+    def _compose_index_document(self, issue: JiraIssue) -> str:
+        parts = [issue.summary or "", issue.description or "", " ".join(issue.labels or [])]
+        return "\n".join(part for part in parts if part)
+
+    # ------------------------------------------------------------------
+    # Query APIs
+    # ------------------------------------------------------------------
+    def list_tasks(
+        self,
+        org_id: uuid.UUID,
+        assignee: Optional[str] = None,
+        status: Optional[str] = None,
+        project: Optional[str] = None,
+        updated_since: Optional[datetime] = None,
+    ) -> List[Dict[str, object]]:
+        with session_scope() as session:
+            query = (
+                select(JiraIssue)
+                .join(JiraConnection, JiraIssue.connection_id == JiraConnection.id)
+                .where(JiraConnection.org_id == org_id)
+            )
+
+            if project:
+                query = query.where(func.lower(JiraIssue.project_key) == project.lower())
+            if assignee:
+                query = query.where(func.lower(func.coalesce(JiraIssue.assignee, "")) == assignee.lower())
+            if status:
+                query = query.where(func.lower(func.coalesce(JiraIssue.status, "")) == status.lower())
+            if updated_since:
+                query = query.where(JiraIssue.updated != None, JiraIssue.updated >= updated_since)  # noqa: E711
+
+            query = query.order_by(JiraIssue.updated.desc().nullslast())
+            issues = session.execute(query).scalars().all()
+
+        return [self._issue_to_dict(issue) for issue in issues]
+
+    def search(
+        self,
+        org_id: uuid.UUID,
+        query: str,
+        project: Optional[str] = None,
+        top_k: int = 10,
+    ) -> List[Dict[str, object]]:
+        project_filter = project.lower() if project else None
+
+        with session_scope() as session:
+            stmt = (
+                select(JiraIssue)
+                .join(JiraConnection, JiraIssue.connection_id == JiraConnection.id)
+                .where(JiraConnection.org_id == org_id)
+            )
+            if project_filter:
+                stmt = stmt.where(func.lower(JiraIssue.project_key) == project_filter)
+            issues = session.execute(stmt).scalars().all()
+
+        if not query.strip():
+            return [self._issue_to_dict(issue) for issue in issues[:top_k]]
+
+        vector_scores = {res.issue_key: res.score for res in self._vector_store.search(query, limit=top_k * 2)}
+        ranked: List[Tuple[float, JiraIssue]] = []
+        lowered_query = query.lower()
+        for issue in issues:
+            text = " ".join(filter(None, [issue.summary, issue.description, " ".join(issue.labels or [])])).lower()
+            lexical = -2.0 if lowered_query and lowered_query in text else 0.0
+            vector = vector_scores.get(issue.issue_key, 0.0)
+            combined = lexical + vector
+            ranked.append((combined, issue))
+
+        ranked.sort(key=lambda item: item[0])
+        return [self._issue_to_dict(issue) for _, issue in ranked[:top_k]]
+
+    def get_issue(self, org_id: uuid.UUID, issue_key: str) -> Optional[Dict[str, object]]:
+        with session_scope() as session:
+            stmt = (
+                select(JiraIssue)
+                .join(JiraConnection, JiraIssue.connection_id == JiraConnection.id)
+                .where(
+                    JiraConnection.org_id == org_id,
+                    func.lower(JiraIssue.issue_key) == issue_key.lower(),
+                )
+            )
+            issue = session.execute(stmt).scalars().first()
+        if not issue:
+            return None
+        return self._issue_to_dict(issue, include_raw=True)
+
+    def _issue_to_dict(self, issue: JiraIssue, include_raw: bool = False) -> Dict[str, object]:
+        data = {
+            "key": issue.issue_key,
+            "title": issue.summary,
+            "status": issue.status,
+            "priority": issue.priority,
+            "assignee": issue.assignee,
+            "reporter": issue.reporter,
+            "updated": _format_datetime(issue.updated),
+            "url": issue.url,
+            "project": issue.project_key,
+            "labels": issue.labels or [],
+            "epic_key": issue.epic_key,
+            "sprint": issue.sprint,
+        }
+        if include_raw:
+            data["description"] = issue.description
+            data["raw"] = issue.raw
+        return data
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _get_connection(self, session: Session, org_id: uuid.UUID) -> Optional[JiraConnection]:
+        return (
+            session.execute(select(JiraConnection).where(JiraConnection.org_id == org_id))
+            .scalars()
+            .first()
+        )
+
+
+integration_service = JiraIntegrationService()
+
+
+__all__ = ["integration_service", "JiraIntegrationService", "JiraSyncResult"]

--- a/backend/jira_integration.py
+++ b/backend/jira_integration.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+import logging
 import hashlib
 import json
 import os
@@ -20,6 +21,9 @@ from sqlalchemy.orm import Session
 from backend.db.base import session_scope
 from backend.db.models import JiraConnection, JiraIssue, JiraProjectConfig
 from backend.jira_vector_store import JiraVectorStore
+
+
+logger = logging.getLogger(__name__)
 
 
 JIRA_OAUTH_AUTHORIZE_URL = "https://auth.atlassian.com/authorize"
@@ -347,8 +351,7 @@ class JiraIntegrationService:
             try:
                 self.sync_now(org_id)
             except Exception:
-                # swallow exceptions to avoid crashing the worker thread
-                pass
+                logger.exception("Failed to sync Jira issues for org %s", org_id)
 
     def sync_now(self, org_id: uuid.UUID) -> JiraSyncResult:
         mock_mode = os.getenv("MOCK_JIRA", "false").lower() == "true"

--- a/backend/jira_integration.py
+++ b/backend/jira_integration.py
@@ -519,8 +519,8 @@ class JiraIntegrationService:
         issue = (
             session.execute(
                 select(JiraIssue).where(
-                    JiraIssue.issue_key == issue_key,
                     JiraIssue.connection_id == connection.id,
+                    JiraIssue.issue_key == issue_key,
                 )
             )
             .scalars()

--- a/backend/jira_integration.py
+++ b/backend/jira_integration.py
@@ -588,7 +588,7 @@ class JiraIntegrationService:
             if status:
                 query = query.where(func.lower(func.coalesce(JiraIssue.status, "")) == status.lower())
             if updated_since:
-                query = query.where(JiraIssue.updated != None, JiraIssue.updated >= updated_since)  # noqa: E711
+                query = query.where(JiraIssue.updated is not None, JiraIssue.updated >= updated_since)
 
             query = query.order_by(JiraIssue.updated.desc().nullslast())
             issues = session.execute(query).scalars().all()

--- a/backend/jira_integration.py
+++ b/backend/jira_integration.py
@@ -516,7 +516,12 @@ class JiraIntegrationService:
         url = f"{connection.cloud_base_url.rstrip('/')}/browse/{issue_key}"
 
         issue = (
-            session.execute(select(JiraIssue).where(JiraIssue.issue_key == issue_key))
+            session.execute(
+                select(JiraIssue).where(
+                    JiraIssue.issue_key == issue_key,
+                    JiraIssue.connection_id == connection.id,
+                )
+            )
             .scalars()
             .first()
         )

--- a/backend/jira_vector_store.py
+++ b/backend/jira_vector_store.py
@@ -11,7 +11,7 @@ try:  # pragma: no cover - optional dependency
     from chromadb.utils.embedding_functions import (  # type: ignore
         DefaultEmbeddingFunction,
     )
-except Exception:  # pragma: no cover - fallback when chromadb unavailable
+except (ImportError, ModuleNotFoundError):  # pragma: no cover - fallback when chromadb unavailable
     chromadb = None
 
     class Settings:  # type: ignore[override]

--- a/backend/jira_vector_store.py
+++ b/backend/jira_vector_store.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Dict, List, Tuple
+
+try:  # pragma: no cover - optional dependency
+    import chromadb  # type: ignore
+    from chromadb.config import Settings  # type: ignore
+    from chromadb.utils.embedding_functions import (  # type: ignore
+        DefaultEmbeddingFunction,
+    )
+except Exception:  # pragma: no cover - fallback when chromadb unavailable
+    chromadb = None
+
+    class Settings:  # type: ignore[override]
+        def __init__(self, persist_directory: str | None = None):
+            self.persist_directory = persist_directory
+
+    class DefaultEmbeddingFunction:  # type: ignore[override]
+        def __call__(self, texts: List[str]):
+            return [[float(len(text))] for text in texts]
+
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class JiraVectorResult:
+    issue_key: str
+    score: float
+
+
+class JiraVectorStore:
+    """Minimal vector index wrapper for Jira issue search."""
+
+    def __init__(self, collection_name: str = "jira_issues") -> None:
+        persist_dir = os.getenv("MEMORY_DB_PATH", "./memory_db")
+        self._fallback_store: Dict[str, str] = {}
+        if chromadb:
+            try:
+                self._client = chromadb.Client(Settings(persist_directory=persist_dir))
+                self._collection = self._client.get_or_create_collection(
+                    collection_name,
+                    embedding_function=DefaultEmbeddingFunction(),
+                )
+            except Exception as exc:  # pragma: no cover - fallback path
+                log.warning("Falling back to in-memory Chroma client: %s", exc)
+                self._client = chromadb.Client(Settings())
+                self._collection = self._client.get_or_create_collection(
+                    collection_name,
+                    embedding_function=DefaultEmbeddingFunction(),
+                )
+        else:
+            self._client = None
+            self._collection = None
+
+    def index_issue(self, issue_key: str, document: str, metadata: Dict[str, str]) -> None:
+        if not document.strip():
+            document = metadata.get("summary", "")
+
+        if self._collection is not None:
+            self._collection.upsert(
+                ids=[issue_key],
+                documents=[document],
+                metadatas=[metadata],
+            )
+        else:
+            combined = " ".join([document, metadata.get("summary", ""), metadata.get("status", "")])
+            self._fallback_store[issue_key] = combined
+
+    def delete_issue(self, issue_key: str) -> None:
+        if self._collection is not None:
+            self._collection.delete(ids=[issue_key])
+        else:
+            self._fallback_store.pop(issue_key, None)
+
+    def search(self, query: str, limit: int = 10) -> List[JiraVectorResult]:
+        if not query.strip():
+            return []
+
+        if self._collection is not None:
+            results = self._collection.query(query_texts=[query], n_results=limit)
+            ids = results.get("ids", [[]])[0]
+            distances = results.get("distances", [[]])[0] or []
+            return [JiraVectorResult(issue_key=_id, score=float(distance)) for _id, distance in zip(ids, distances)]
+
+        scores: List[Tuple[str, float]] = []
+        lower_query = query.lower()
+        for issue_key, text in self._fallback_store.items():
+            text_lower = text.lower()
+            if lower_query in text_lower:
+                score = float(text_lower.count(lower_query)) * -1.0
+            else:
+                continue
+            scores.append((issue_key, score))
+        scores.sort(key=lambda item: item[1])
+        return [JiraVectorResult(issue_key=issue_key, score=score) for issue_key, score in scores[:limit]]
+
+
+__all__ = ["JiraVectorStore", "JiraVectorResult"]

--- a/backend/server.py
+++ b/backend/server.py
@@ -20,8 +20,10 @@ CORS(app)
 # Ship-It PR: Add healthz blueprint
 from backend.healthz import bp as healthz_bp
 from backend.webhooks_jira import bp as jira_bp
+from backend.jira_api import bp as jira_integration_bp
 app.register_blueprint(healthz_bp)
 app.register_blueprint(jira_bp)
+app.register_blueprint(jira_integration_bp)
 
 # Ship-It PR: Add middleware for rate limiting and cost tracking
 from backend.middleware import rate_limit, record_cost

--- a/tests/fixtures/jira/issues.json
+++ b/tests/fixtures/jira/issues.json
@@ -1,0 +1,49 @@
+{
+  "issues": [
+    {
+      "id": "1",
+      "key": "PROJ-1",
+      "fields": {
+        "summary": "Implement OAuth flow",
+        "description": "Implement endpoints for Jira integration",
+        "status": {"name": "In Progress"},
+        "priority": {"name": "High"},
+        "assignee": {"displayName": "Alice Doe"},
+        "reporter": {"displayName": "Bob Doe"},
+        "labels": ["integration", "oauth"],
+        "project": {"key": "PROJ"},
+        "updated": "2024-03-14T10:00:00.000+0000"
+      }
+    },
+    {
+      "id": "2",
+      "key": "PROJ-2",
+      "fields": {
+        "summary": "Design search ranking",
+        "description": "Blend lexical and semantic scores",
+        "status": {"name": "To Do"},
+        "priority": {"name": "Medium"},
+        "assignee": {"displayName": "Bob Doe"},
+        "reporter": {"displayName": "Alice Doe"},
+        "labels": ["search"],
+        "project": {"key": "PROJ"},
+        "updated": "2024-03-13T08:30:00.000+0000"
+      }
+    },
+    {
+      "id": "3",
+      "key": "OPS-7",
+      "fields": {
+        "summary": "Stabilize integration worker",
+        "description": "Ensure retry logic for rate limits",
+        "status": {"name": "In Progress"},
+        "priority": {"name": "High"},
+        "assignee": {"displayName": "Ops Bot"},
+        "reporter": {"displayName": "Ops Lead"},
+        "labels": ["ops", "worker"],
+        "project": {"key": "OPS"},
+        "updated": "2024-03-15T12:45:00.000+0000"
+      }
+    }
+  ]
+}

--- a/tests/test_jira_integration.py
+++ b/tests/test_jira_integration.py
@@ -1,0 +1,311 @@
+from __future__ import annotations
+
+import copy
+import importlib
+import sys
+import uuid
+import time
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+import pytest
+
+
+@dataclass
+class JiraTestEnv:
+    jira_module: object
+    models: object
+
+
+@pytest.fixture
+def jira_env(tmp_path, monkeypatch) -> Iterable[JiraTestEnv]:
+    db_path = tmp_path / "jira.db"
+    memory_path = tmp_path / "memory"
+    monkeypatch.setenv("KNOWLEDGE_DATABASE_URL", f"sqlite:///{db_path}")
+    monkeypatch.setenv("MEMORY_DB_PATH", str(memory_path))
+    monkeypatch.setenv("JIRA_ENCRYPTION_KEY", "integration-test-key")
+
+    db_base = importlib.import_module("backend.db.base")
+    models = importlib.import_module("backend.db.models")
+    jira_module = importlib.import_module("backend.jira_integration")
+
+    db_base.get_sessionmaker(f"sqlite:///{db_path}")
+    engine = db_base.get_engine()
+    tables = [
+        models.JiraConnection.__table__,
+        models.JiraProjectConfig.__table__,
+        models.JiraIssue.__table__,
+    ]
+    for table in tables:
+        table.drop(engine, checkfirst=True)
+    for table in tables:
+        table.create(engine, checkfirst=True)
+    jira_module.integration_service = jira_module.JiraIntegrationService()
+
+    yield JiraTestEnv(jira_module=jira_module, models=models)
+
+    for table in tables:
+        table.drop(engine, checkfirst=True)
+
+
+def _create_connection(env: JiraTestEnv, org_id: uuid.UUID, user_id: uuid.UUID, **kwargs):
+    jira = env.jira_module
+    models = env.models
+    with jira.session_scope() as session:
+        connection = models.JiraConnection(
+            org_id=org_id,
+            user_id=user_id,
+            cloud_base_url=kwargs.get("cloud_base_url", "https://example.atlassian.net"),
+            client_id=kwargs.get("client_id", "client"),
+            token_type=kwargs.get("token_type", "Bearer"),
+            access_token=jira._encrypt(kwargs.get("access_token", "token")),
+            refresh_token=jira._encrypt(kwargs.get("refresh_token", "refresh")),
+            expires_at=kwargs.get("expires_at", jira._now() + timedelta(hours=1)),
+            scopes=kwargs.get("scopes", ["read:jira-work"]),
+        )
+        session.add(connection)
+        session.flush()
+        connection_id = connection.id
+    return connection_id
+
+
+def _create_config(env: JiraTestEnv, org_id: uuid.UUID, connection_id, project_keys: List[str]):
+    jira = env.jira_module
+    models = env.models
+    with jira.session_scope() as session:
+        config = models.JiraProjectConfig(
+            org_id=org_id,
+            connection_id=connection_id,
+            project_keys=project_keys,
+        )
+        session.add(config)
+        session.flush()
+        return config.id
+
+
+def test_token_refresh_updates_connection(jira_env, monkeypatch):
+    env = jira_env
+    jira = env.jira_module
+    models = env.models
+    monkeypatch.delenv("MOCK_JIRA", raising=False)
+    monkeypatch.setenv("JIRA_CLIENT_SECRET", "super-secret")
+
+    org_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+    connection_id = _create_connection(
+        env,
+        org_id,
+        user_id,
+        access_token="expired-token",
+        refresh_token="refresh-token",
+        expires_at=jira._now() - timedelta(seconds=5),
+    )
+
+    calls: Dict[str, Dict[str, object]] = {}
+
+    class _TokenResponse:
+        status_code = 200
+
+        def json(self):
+            return {"access_token": "new-access", "expires_in": 3600}
+
+        def raise_for_status(self):
+            return None
+
+    def _fake_post(url, json=None, timeout=None):
+        calls["payload"] = json
+        return _TokenResponse()
+
+    monkeypatch.setattr(jira.requests, "post", _fake_post)
+
+    with jira.session_scope() as session:
+        connection = session.get(models.JiraConnection, connection_id)
+        token = jira.integration_service._ensure_access_token(session, connection)
+
+    assert token == "new-access"
+    assert calls["payload"]["grant_type"] == "refresh_token"
+    with jira.session_scope() as session:
+        connection = session.get(models.JiraConnection, connection_id)
+        assert jira._decrypt(connection.access_token) == "new-access"
+
+
+def test_sync_upsert_and_status(jira_env, monkeypatch):
+    env = jira_env
+    jira = env.jira_module
+    models = env.models
+    monkeypatch.setenv("MOCK_JIRA", "true")
+
+    org_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+    connection_id = _create_connection(env, org_id, user_id)
+    _create_config(env, org_id, connection_id, ["PROJ", "OPS"])
+
+    result = jira.integration_service.sync_now(org_id)
+    assert result.fetched == 3
+    assert result.updated == 3
+    assert result.indexed == 3
+
+    status = jira.integration_service.get_status(org_id)
+    assert status["connected"] is True
+    assert set(status["projects"]) == {"PROJ", "OPS"}
+
+    tasks = jira.integration_service.list_tasks(org_id, assignee="Alice Doe", status="In Progress", project="PROJ")
+    assert len(tasks) == 1
+    assert tasks[0]["key"] == "PROJ-1"
+
+    original_loader = jira._load_mock_fixture
+
+    def _patched_loader(name: str):
+        data = original_loader(name)
+        if name == "issues.json":
+            updated = copy.deepcopy(data)
+            updated["issues"][0]["fields"]["summary"] = "Implement OAuth flow (updated)"
+            return updated
+        return data
+
+    monkeypatch.setattr(jira, "_load_mock_fixture", _patched_loader)
+    jira.integration_service.sync_now(org_id)
+
+    with jira.session_scope() as session:
+        issue = (
+            session.query(models.JiraIssue)
+            .filter(models.JiraIssue.issue_key == "PROJ-1")
+            .one()
+        )
+        assert issue.summary.endswith("(updated)")
+
+
+def test_fetch_pagination_handles_multiple_pages(jira_env, monkeypatch):
+    env = jira_env
+    jira = env.jira_module
+    models = env.models
+    monkeypatch.delenv("MOCK_JIRA", raising=False)
+
+    org_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+    connection_id = _create_connection(env, org_id, user_id)
+
+    with jira.session_scope() as session:
+        connection = session.get(models.JiraConnection, connection_id)
+
+    responses = [
+        {
+            "issues": [
+                {"key": "PROJ-10", "fields": {"project": {"key": "PROJ"}, "summary": "Page1"}},
+                {"key": "PROJ-11", "fields": {"project": {"key": "PROJ"}, "summary": "Page1B"}},
+            ],
+            "total": 3,
+        },
+        {
+            "issues": [
+                {"key": "PROJ-12", "fields": {"project": {"key": "PROJ"}, "summary": "Page2"}},
+            ],
+            "total": 3,
+        },
+    ]
+    calls: List[int] = []
+
+    class _Resp:
+        def __init__(self, payload):
+            self.payload = payload
+            self.status_code = 200
+            self.headers = {}
+
+        def json(self):
+            return self.payload
+
+        def raise_for_status(self):
+            return None
+
+    def _fake_get(url, headers=None, params=None, timeout=None):
+        calls.append(params["startAt"])
+        payload = responses[len(calls) - 1]
+        return _Resp(payload)
+
+    monkeypatch.setattr(jira.requests, "get", _fake_get)
+
+    issues = list(jira.integration_service._fetch_issues(connection, "token", "project=PROJ", mock_mode=False, max_results=2))
+    assert len(issues) == 3
+    assert calls == [0, 2]
+
+
+def test_integration_flow_and_search(jira_env, monkeypatch):
+    env = jira_env
+    jira = env.jira_module
+    monkeypatch.setenv("MOCK_JIRA", "true")
+
+    org_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+
+    start = jira.integration_service.start_oauth(org_id, user_id)
+    assert "auth_url" in start
+    state = start["state"]
+
+    callback = jira.integration_service.complete_oauth("dummy-code", state=state)
+    assert callback["connected"] is True
+
+    jira.integration_service.update_project_config(org_id, user_id, project_keys=["PROJ", "OPS"])
+    jira.integration_service.sync_now(org_id)
+
+    tasks = jira.integration_service.list_tasks(org_id, assignee="Alice Doe", project="PROJ")
+    assert tasks and tasks[0]["key"] == "PROJ-1"
+
+    results = jira.integration_service.search(org_id, "integration", project="PROJ")
+    assert results and results[0]["key"] == "PROJ-1"
+
+    detail = jira.integration_service.get_issue(org_id, "PROJ-1")
+    assert detail["key"] == "PROJ-1"
+    assert detail["description"]
+
+
+def test_sync_handles_large_batch_quickly(jira_env, monkeypatch):
+    env = jira_env
+    jira = env.jira_module
+    models = env.models
+    monkeypatch.setenv("MOCK_JIRA", "false")
+
+    org_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+    connection_id = _create_connection(env, org_id, user_id)
+    _create_config(env, org_id, connection_id, ["LOAD"])
+
+    issues = []
+    base_time = datetime(2024, 3, 1, tzinfo=timezone.utc)
+    for idx in range(5000):
+        key = f"LOAD-{idx}"
+        issues.append(
+            {
+                "key": key,
+                "fields": {
+                    "summary": f"Bulk issue {idx}",
+                    "description": "Synthetic data",
+                    "status": {"name": "In Progress"},
+                    "project": {"key": "LOAD"},
+                    "updated": (base_time + timedelta(minutes=idx)).isoformat(),
+                },
+            }
+        )
+
+    def _fake_fetch(connection, access_token, jql, mock_mode=False, max_results=100):
+        return iter(issues)
+
+    monkeypatch.setattr(jira.integration_service, "_fetch_issues", _fake_fetch)
+    monkeypatch.setattr(jira.integration_service, "_ensure_access_token", lambda session, conn: "token")
+
+    start = time.time()
+    result = jira.integration_service.sync_now(org_id)
+    duration = time.time() - start
+
+    assert result.fetched == 5000
+    assert result.updated == 5000
+    assert duration < 5
+
+    with jira.session_scope() as session:
+        count = session.query(models.JiraIssue).count()
+    assert count == 5000


### PR DESCRIPTION
## Summary
- add Jira OAuth endpoints, configuration APIs, sync trigger, issue listing, and search routes
- implement Jira persistence models, migrations, and sync worker with vector-backed hybrid search plus mock fixtures
- add regression tests covering token refresh, incremental sync, pagination, search, and large batch performance

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e69baaabd48323a2a6834b7846638b