### PR TITLE
Handle empty Jira responses for update and transition

### DIFF
--- a/backend/integrations/jira_manager.py
+++ b/backend/integrations/jira_manager.py
@@ -21,7 +21,7 @@ def _json_or_empty(response: requests.Response) -> Dict[str, Any]:
     payload to decode.
     """
 
-    if response.status_code == 204 or not response.content:
+    if response.status_code == 204 or response.text.strip() == '':
         return {}
     return response.json()
 


### PR DESCRIPTION
## Summary
- add a helper that returns an empty payload when Jira sends 204 responses
- use the helper in update_issue and transition_issue so JSON parsing no longer crashes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6c2aa699c83238ed6f528591be89f