### PR TITLE
Add Jira integration read-only MVP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,7 @@ demo_*.py
 setup_*.sh
 data/*.db
 !tests/test_meeting_intelligence.py
+!tests/test_jira_integration.py
 
 # Internal documentation
 INTERNAL_README.md

--- a/backend/db/migrations/versions/20240501000001_jira_tables.py
+++ b/backend/db/migrations/versions/20240501000001_jira_tables.py
@@ -1,0 +1,78 @@
+"""create jira integration tables
+
+Revision ID: 20240501000001
+Revises: 20240223000000
+Create Date: 2024-05-01 00:00:01.000000
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision = "20240501000001"
+down_revision = "20240223000000"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    text_array = postgresql.ARRAY(sa.Text()).with_variant(sa.JSON(), "sqlite")
+    uuid_type = postgresql.UUID(as_uuid=True).with_variant(sa.String(length=36), "sqlite")
+
+    op.create_table(
+        "jira_connection",
+        sa.Column("id", uuid_type, primary_key=True),
+        sa.Column("org_id", uuid_type, nullable=False),
+        sa.Column("user_id", uuid_type, nullable=False),
+        sa.Column("cloud_base_url", sa.Text(), nullable=False),
+        sa.Column("client_id", sa.Text(), nullable=False),
+        sa.Column("token_type", sa.Text(), nullable=True),
+        sa.Column("access_token", sa.Text(), nullable=True),
+        sa.Column("refresh_token", sa.Text(), nullable=True),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("scopes", text_array, nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+
+    op.create_table(
+        "jira_project_config",
+        sa.Column("id", uuid_type, primary_key=True),
+        sa.Column("org_id", uuid_type, nullable=False),
+        sa.Column("connection_id", uuid_type, sa.ForeignKey("jira_connection.id"), nullable=False),
+        sa.Column("project_keys", text_array, nullable=False),
+        sa.Column("board_ids", text_array, nullable=True),
+        sa.Column("default_jql", sa.Text(), nullable=True),
+        sa.Column("last_sync_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+    op.create_table(
+        "jira_issue",
+        sa.Column("id", uuid_type, primary_key=True),
+        sa.Column("connection_id", uuid_type, sa.ForeignKey("jira_connection.id"), nullable=False),
+        sa.Column("project_key", sa.Text(), nullable=False),
+        sa.Column("issue_key", sa.Text(), unique=True, nullable=False),
+        sa.Column("summary", sa.Text(), nullable=True),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("status", sa.Text(), nullable=True),
+        sa.Column("priority", sa.Text(), nullable=True),
+        sa.Column("assignee", sa.Text(), nullable=True),
+        sa.Column("reporter", sa.Text(), nullable=True),
+        sa.Column("labels", text_array, nullable=True),
+        sa.Column("epic_key", sa.Text(), nullable=True),
+        sa.Column("sprint", sa.Text(), nullable=True),
+        sa.Column("updated", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("url", sa.Text(), nullable=True),
+        sa.Column("raw", sa.JSON(), nullable=True),
+        sa.Column("indexed_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("jira_issue")
+    op.drop_table("jira_project_config")
+    op.drop_table("jira_connection")
+

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import datetime
 
 from sqlalchemy import Column, DateTime, ForeignKey, Integer, Numeric, String, Text
-from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB, UUID
 from sqlalchemy.types import JSON
 
 from .base import Base
@@ -59,3 +59,56 @@ class ActionItem(Base):
     due_hint = Column(String(255))
     confidence = Column(Numeric)
     source_segment = Column(UUID(as_uuid=True), ForeignKey("transcript_segment.id"), nullable=True)
+
+
+TextArray = ARRAY(Text).with_variant(JSON(), "sqlite")
+
+
+class JiraConnection(Base):
+    __tablename__ = "jira_connection"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id = Column(UUID(as_uuid=True), nullable=False)
+    user_id = Column(UUID(as_uuid=True), nullable=False)
+    cloud_base_url = Column(Text, nullable=False)
+    client_id = Column(Text, nullable=False)
+    token_type = Column(Text, nullable=True)
+    access_token = Column(Text, nullable=True)
+    refresh_token = Column(Text, nullable=True)
+    expires_at = Column(DateTime(timezone=True), nullable=True)
+    scopes = Column(TextArray, nullable=True)
+    created_at = Column(DateTime(timezone=True), default=datetime.utcnow)
+
+
+class JiraProjectConfig(Base):
+    __tablename__ = "jira_project_config"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id = Column(UUID(as_uuid=True), nullable=False)
+    connection_id = Column(UUID(as_uuid=True), ForeignKey("jira_connection.id"), nullable=False)
+    project_keys = Column(TextArray, nullable=False, default=list)
+    board_ids = Column(TextArray, nullable=True)
+    default_jql = Column(Text, nullable=True)
+    last_sync_at = Column(DateTime(timezone=True), nullable=True)
+
+
+class JiraIssue(Base):
+    __tablename__ = "jira_issue"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    connection_id = Column(UUID(as_uuid=True), ForeignKey("jira_connection.id"), nullable=False)
+    project_key = Column(Text, nullable=False)
+    issue_key = Column(Text, unique=True, nullable=False)
+    summary = Column(Text, nullable=True)
+    description = Column(Text, nullable=True)
+    status = Column(Text, nullable=True)
+    priority = Column(Text, nullable=True)
+    assignee = Column(Text, nullable=True)
+    reporter = Column(Text, nullable=True)
+    labels = Column(TextArray, nullable=True)
+    epic_key = Column(Text, nullable=True)
+    sprint = Column(Text, nullable=True)
+    updated = Column(DateTime(timezone=True), nullable=True)
+    url = Column(Text, nullable=True)
+    raw = _jsonb_column("raw")
+    indexed_at = Column(DateTime(timezone=True), nullable=True)

--- a/backend/integrations/__init__.py
+++ b/backend/integrations/__init__.py
@@ -1,1 +1,7 @@
 # backend/integrations/__init__.py
+
+"""Integration utilities and services."""
+
+from .jira_routes import service as jira_service
+
+__all__ = ["jira_service"]

--- a/backend/integrations/jira_crypto.py
+++ b/backend/integrations/jira_crypto.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import os
+from typing import Optional
+
+try:
+    from cryptography.fernet import Fernet
+except Exception:  # pragma: no cover - optional dependency fallback
+    Fernet = None  # type: ignore
+
+
+class JiraTokenCipher:
+    """Encrypt and decrypt Jira OAuth tokens using Fernet when available."""
+
+    def __init__(self, key: Optional[str] = None) -> None:
+        provided = key or os.getenv("JIRA_ENCRYPTION_KEY") or os.getenv("ENCRYPTION_KEY")
+        self._fernet = self._build_fernet(provided)
+
+    @staticmethod
+    def _build_fernet(key: Optional[str]) -> Optional[Fernet]:
+        if not key or Fernet is None:
+            return None
+        key_bytes = key.encode()
+        if len(key_bytes) == 44 and key.endswith("="):
+            candidate = key_bytes
+        else:
+            digest = hashlib.sha256(key_bytes).digest()
+            candidate = base64.urlsafe_b64encode(digest)
+        try:
+            return Fernet(candidate)
+        except Exception:  # pragma: no cover - invalid key fallback
+            return None
+
+    def encrypt(self, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        if self._fernet is None:
+            return value
+        return self._fernet.encrypt(value.encode()).decode()
+
+    def decrypt(self, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        if self._fernet is None:
+            return value
+        return self._fernet.decrypt(value.encode()).decode()
+
+
+__all__ = ["JiraTokenCipher"]

--- a/backend/integrations/jira_routes.py
+++ b/backend/integrations/jira_routes.py
@@ -125,6 +125,11 @@ def jira_search():
         top_k = int(request.args.get("top_k", 10))
     except ValueError:
         top_k = 10
+    # Cap top_k to prevent excessive resource usage
+    if top_k < 1:
+        top_k = 1
+    elif top_k > 100:
+        top_k = 100
     results = service.search(org_id, query, project, top_k=top_k)
     return jsonify(results)
 

--- a/backend/integrations/jira_routes.py
+++ b/backend/integrations/jira_routes.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from flask import Blueprint, jsonify, request
+
+from .jira_service import JiraIntegrationService
+
+
+bp = Blueprint("jira_integration", __name__)
+service = JiraIntegrationService()
+
+
+def _context():
+    org_id, user_id = service.resolve_context(request.headers)
+    return org_id, user_id
+
+
+@bp.route("/api/integrations/jira/oauth/start", methods=["POST"])
+def jira_oauth_start():
+    state = request.json.get("state") if request.is_json else None
+    payload = service.build_oauth_url(state=state)
+    return jsonify(payload)
+
+
+@bp.route("/api/integrations/jira/oauth/callback", methods=["GET"])
+def jira_oauth_callback():
+    code = request.args.get("code")
+    if not code:
+        return jsonify({"error": "missing code"}), 400
+    org_id, user_id = _context()
+    tokens = service.exchange_code_for_tokens(code)
+    cloud_base_url = request.args.get("cloud_base_url") or request.headers.get(
+        "X-Jira-Base-Url", "https://example.atlassian.net"
+    )
+    connection = service.store_tokens(
+        org_id=org_id,
+        user_id=user_id,
+        cloud_base_url=cloud_base_url,
+        tokens=tokens,
+    )
+    return jsonify({"ok": True, "connection_id": str(connection.id)})
+
+
+@bp.route("/api/integrations/jira/config", methods=["POST"])
+def jira_config():
+    if not request.is_json:
+        return jsonify({"error": "invalid payload"}), 400
+    data = request.get_json() or {}
+    project_keys = data.get("project_keys") or []
+    if not project_keys:
+        return jsonify({"error": "project_keys required"}), 400
+    org_id, user_id = _context()
+    status = service.get_status(org_id)
+    if not status.get("connected"):
+        return jsonify({"error": "oauth required"}), 400
+
+    connection_id = data.get("connection_id")
+    if not connection_id:
+        status = service.get_status(org_id)
+        if not status.get("connected"):
+            return jsonify({"error": "oauth required"}), 400
+        # Fetch latest connection
+        from backend.db.base import session_scope
+        from backend.db.models import JiraConnection
+
+        with session_scope() as session:
+            connection = (
+                session.query(JiraConnection)
+                .filter(JiraConnection.org_id == org_id)
+                .order_by(JiraConnection.created_at.desc())
+                .first()
+            )
+            if not connection:
+                return jsonify({"error": "oauth required"}), 400
+            connection_id = connection.id
+
+    config = service.update_project_config(
+        org_id=org_id,
+        connection_id=connection_id,
+        project_keys=project_keys,
+        board_ids=data.get("board_ids") or [],
+        default_jql=data.get("default_jql"),
+    )
+    return jsonify({"ok": True, "config_id": str(config.id)})
+
+
+@bp.route("/api/integrations/jira/status", methods=["GET"])
+def jira_status():
+    org_id, _ = _context()
+    status = service.get_status(org_id)
+    return jsonify(status)
+
+
+@bp.route("/api/integrations/jira/sync", methods=["POST"])
+def jira_sync():
+    org_id, _ = _context()
+    result = service.worker.enqueue(org_id)
+    return jsonify(result)
+
+
+@bp.route("/api/jira/tasks", methods=["GET"])
+def jira_tasks():
+    org_id, _ = _context()
+    assignee = request.args.get("assignee")
+    status = request.args.get("status")
+    project = request.args.get("project")
+    updated_since = request.args.get("updated_since")
+    me_identifier = request.headers.get("X-Jira-User")
+    tasks = service.list_tasks(
+        org_id,
+        assignee,
+        status,
+        project,
+        updated_since,
+        me_identifier=me_identifier,
+    )
+    return jsonify(tasks)
+
+
+@bp.route("/api/jira/search", methods=["GET"])
+def jira_search():
+    org_id, _ = _context()
+    query = request.args.get("q", "")
+    project = request.args.get("project")
+    try:
+        top_k = int(request.args.get("top_k", 10))
+    except ValueError:
+        top_k = 10
+    results = service.search(org_id, query, project, top_k=top_k)
+    return jsonify(results)
+
+
+@bp.route("/api/jira/issues/<key>", methods=["GET"])
+def jira_issue(key: str):
+    org_id, _ = _context()
+    issue = service.get_issue(org_id, key)
+    if not issue:
+        return jsonify({"error": "not found"}), 404
+    return jsonify(issue)
+
+
+__all__ = ["bp", "service"]

--- a/backend/integrations/jira_service.py
+++ b/backend/integrations/jira_service.py
@@ -1,0 +1,658 @@
+from __future__ import annotations
+
+import datetime as dt
+import json
+import os
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+import requests
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from backend.db.base import session_scope
+from backend.db.models import JiraConnection, JiraIssue, JiraProjectConfig
+
+from .jira_crypto import JiraTokenCipher
+from .jira_vector_store import JiraIssueVectorStore
+
+
+DEFAULT_RETRY_BACKOFF = [1, 2, 4, 8]
+FIXTURES_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "tests", "fixtures", "jira")
+)
+
+
+def _parse_uuid(value: str, fallback_namespace: uuid.UUID) -> uuid.UUID:
+    try:
+        return uuid.UUID(str(value))
+    except Exception:
+        return uuid.uuid5(fallback_namespace, str(value))
+
+
+def _now() -> dt.datetime:
+    return dt.datetime.now(dt.timezone.utc)
+
+
+def _parse_datetime(value: Optional[str]) -> Optional[dt.datetime]:
+    if not value:
+        return None
+    try:
+        return dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except Exception:
+        return None
+
+
+def _stringify_scopes(scopes: str | List[str] | None) -> List[str]:
+    if scopes is None:
+        return []
+    if isinstance(scopes, str):
+        return [scope.strip() for scope in scopes.split(" ") if scope.strip()]
+    return scopes
+
+
+@dataclass
+class OAuthTokens:
+    access_token: str
+    refresh_token: str
+    token_type: str
+    expires_in: int
+    scope: List[str]
+
+
+class JiraSyncWorker:
+    """Simple background worker for Jira sync operations."""
+
+    def __init__(self, service: "JiraIntegrationService") -> None:
+        self._service = service
+        self._lock = threading.Lock()
+        self._pending: set[uuid.UUID] = set()
+        self._threads: List[threading.Thread] = []
+
+    def enqueue(self, org_id: uuid.UUID) -> Dict[str, Any]:
+        inline = os.getenv("JIRA_SYNC_INLINE", "false").lower() == "true"
+        if inline:
+            summary = self._service.perform_sync(org_id)
+            summary["mode"] = "inline"
+            return summary
+
+        with self._lock:
+            if org_id in self._pending:
+                return {"queued": False, "message": "sync already running"}
+            self._pending.add(org_id)
+
+        thread = threading.Thread(target=self._run, args=(org_id,), daemon=True)
+        self._threads.append(thread)
+        thread.start()
+        return {"queued": True}
+
+    def _run(self, org_id: uuid.UUID) -> None:
+        try:
+            self._service.perform_sync(org_id)
+        finally:
+            with self._lock:
+                self._pending.discard(org_id)
+
+
+class JiraIntegrationService:
+    """Service encapsulating Jira OAuth, configuration, sync and search."""
+
+    def __init__(self, *, vector_store: Optional[JiraIssueVectorStore] = None) -> None:
+        self.mock_mode = os.getenv("MOCK_JIRA", "false").lower() == "true"
+        self.cipher = JiraTokenCipher()
+        self.vector_store = vector_store or JiraIssueVectorStore()
+        self.worker = JiraSyncWorker(self)
+
+    # ------------------------------------------------------------------
+    # Context helpers
+    def resolve_context(self, headers: Dict[str, str]) -> Tuple[uuid.UUID, uuid.UUID]:
+        namespace = uuid.UUID("00000000-0000-0000-0000-000000000000")
+        org_raw = headers.get("X-Org-ID") or os.getenv("DEFAULT_ORG_ID", "org-default")
+        user_raw = headers.get("X-User-ID") or headers.get("X-User-Email") or os.getenv(
+            "DEFAULT_USER_ID", "user-default"
+        )
+        org_id = _parse_uuid(org_raw, namespace)
+        user_id = _parse_uuid(user_raw, org_id)
+        return org_id, user_id
+
+    # ------------------------------------------------------------------
+    # OAuth
+    def build_oauth_url(self, state: Optional[str] = None) -> Dict[str, str]:
+        if self.mock_mode:
+            return {"url": "https://mock.atlassian.net/oauth"}
+
+        client_id = os.getenv("JIRA_CLIENT_ID", "")
+        redirect_uri = os.getenv("JIRA_REDIRECT_URI", "http://localhost:5000/api/integrations/jira/oauth/callback")
+        scope = os.getenv(
+            "JIRA_DEFAULT_SCOPES",
+            "read:jira-user read:jira-work offline_access",
+        )
+        authorize_base = "https://auth.atlassian.com/authorize"
+        params = {
+            "audience": "api.atlassian.com",
+            "client_id": client_id,
+            "scope": scope,
+            "redirect_uri": redirect_uri,
+            "response_type": "code",
+            "prompt": "consent",
+        }
+        if state:
+            params["state"] = state
+        query = "&".join(f"{key}={requests.utils.quote(str(value))}" for key, value in params.items())
+        return {"url": f"{authorize_base}?{query}"}
+
+    def exchange_code_for_tokens(self, code: str) -> OAuthTokens:
+        if self.mock_mode:
+            fixture_path = os.path.join(FIXTURES_ROOT, "oauth_tokens.json")
+            with open(fixture_path, "r", encoding="utf-8") as handle:
+                payload = json.load(handle)
+        else:
+            client_id = os.getenv("JIRA_CLIENT_ID", "")
+            client_secret = os.getenv("JIRA_CLIENT_SECRET", "")
+            redirect_uri = os.getenv(
+                "JIRA_REDIRECT_URI", "http://localhost:5000/api/integrations/jira/oauth/callback"
+            )
+            token_endpoint = "https://auth.atlassian.com/oauth/token"
+            data = {
+                "grant_type": "authorization_code",
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "code": code,
+                "redirect_uri": redirect_uri,
+            }
+            response = requests.post(token_endpoint, json=data, timeout=30)
+            response.raise_for_status()
+            payload = response.json()
+
+        scopes = _stringify_scopes(payload.get("scope"))
+        return OAuthTokens(
+            access_token=payload.get("access_token", ""),
+            refresh_token=payload.get("refresh_token", ""),
+            token_type=payload.get("token_type", "Bearer"),
+            expires_in=int(payload.get("expires_in", 3600)),
+            scope=scopes,
+        )
+
+    def store_tokens(
+        self,
+        *,
+        org_id: uuid.UUID,
+        user_id: uuid.UUID,
+        cloud_base_url: str,
+        tokens: OAuthTokens,
+    ) -> JiraConnection:
+        with session_scope() as session:
+            connection = (
+                session.execute(
+                    select(JiraConnection).where(
+                        JiraConnection.org_id == org_id,
+                        JiraConnection.user_id == user_id,
+                    )
+                )
+                .scalars()
+                .one_or_none()
+            )
+
+            expires_at = _now() + dt.timedelta(seconds=tokens.expires_in - 30)
+            encrypted_access = self.cipher.encrypt(tokens.access_token)
+            encrypted_refresh = self.cipher.encrypt(tokens.refresh_token)
+
+            if connection is None:
+                connection = JiraConnection(
+                    org_id=org_id,
+                    user_id=user_id,
+                    cloud_base_url=cloud_base_url,
+                    client_id=os.getenv("JIRA_CLIENT_ID", ""),
+                    token_type=tokens.token_type,
+                    access_token=encrypted_access,
+                    refresh_token=encrypted_refresh,
+                    expires_at=expires_at,
+                    scopes=tokens.scope,
+                )
+                session.add(connection)
+            else:
+                connection.access_token = encrypted_access
+                connection.refresh_token = encrypted_refresh
+                connection.token_type = tokens.token_type
+                connection.expires_at = expires_at
+                connection.scopes = tokens.scope
+                connection.cloud_base_url = cloud_base_url or connection.cloud_base_url
+            session.flush()
+            session.refresh(connection)
+            return connection
+
+    # ------------------------------------------------------------------
+    # Status & Configuration
+    def update_project_config(
+        self,
+        *,
+        org_id: uuid.UUID,
+        connection_id: uuid.UUID,
+        project_keys: List[str],
+        board_ids: Optional[List[str]],
+        default_jql: Optional[str],
+    ) -> JiraProjectConfig:
+        with session_scope() as session:
+            config = (
+                session.execute(
+                    select(JiraProjectConfig).where(
+                        JiraProjectConfig.org_id == org_id,
+                        JiraProjectConfig.connection_id == connection_id,
+                    )
+                )
+                .scalars()
+                .one_or_none()
+            )
+
+            if config is None:
+                config = JiraProjectConfig(
+                    org_id=org_id,
+                    connection_id=connection_id,
+                    project_keys=project_keys,
+                    board_ids=board_ids or [],
+                    default_jql=default_jql,
+                )
+                session.add(config)
+            else:
+                config.project_keys = project_keys
+                config.board_ids = board_ids or []
+                config.default_jql = default_jql
+            session.flush()
+            session.refresh(config)
+            return config
+
+    def get_status(self, org_id: uuid.UUID) -> Dict[str, Any]:
+        with session_scope() as session:
+            connection = (
+                session.execute(
+                    select(JiraConnection).where(JiraConnection.org_id == org_id).order_by(JiraConnection.created_at.desc())
+                )
+                .scalars()
+                .first()
+            )
+
+            if not connection:
+                return {"connected": False, "projects": [], "last_sync_at": None, "scopes": []}
+
+            config = (
+                session.execute(
+                    select(JiraProjectConfig).where(JiraProjectConfig.connection_id == connection.id)
+                )
+                .scalars()
+                .first()
+            )
+
+            return {
+                "connected": True,
+                "last_sync_at": config.last_sync_at.isoformat() if config and config.last_sync_at else None,
+                "projects": config.project_keys if config else [],
+                "scopes": connection.scopes or [],
+            }
+
+    # ------------------------------------------------------------------
+    # Sync
+    def perform_sync(self, org_id: uuid.UUID) -> Dict[str, Any]:
+        processed = 0
+        reindexed = 0
+        with session_scope() as session:
+            configs = (
+                session.execute(select(JiraProjectConfig).where(JiraProjectConfig.org_id == org_id))
+                .scalars()
+                .all()
+            )
+            if not configs:
+                return {"processed": 0, "reindexed": 0}
+
+            for config in configs:
+                connection = session.get(JiraConnection, config.connection_id)
+                if connection is None:
+                    continue
+                connection = self.ensure_access_token(session, connection)
+                issues = list(self._fetch_updated_issues(connection, config))
+                for issue_payload in issues:
+                    issue, reindexed_flag = self._upsert_issue(session, connection, issue_payload)
+                    processed += 1
+                    if reindexed_flag:
+                        reindexed += 1
+                config.last_sync_at = _now()
+            session.flush()
+        return {"processed": processed, "reindexed": reindexed}
+
+    def ensure_access_token(self, session: Session, connection: JiraConnection) -> JiraConnection:
+        expires_at = connection.expires_at or (_now() - dt.timedelta(seconds=1))
+        if expires_at.tzinfo is None:
+            expires_at = expires_at.replace(tzinfo=dt.timezone.utc)
+        if expires_at - _now() > dt.timedelta(minutes=2):
+            return connection
+
+        if self.mock_mode:
+            tokens = self.exchange_code_for_tokens("mock-refresh")
+        else:
+            token_endpoint = "https://auth.atlassian.com/oauth/token"
+            data = {
+                "grant_type": "refresh_token",
+                "client_id": connection.client_id,
+                "client_secret": os.getenv("JIRA_CLIENT_SECRET", ""),
+                "refresh_token": self.cipher.decrypt(connection.refresh_token) or "",
+            }
+            response = requests.post(token_endpoint, json=data, timeout=30)
+            response.raise_for_status()
+            payload = response.json()
+            tokens = OAuthTokens(
+                access_token=payload.get("access_token", ""),
+                refresh_token=payload.get("refresh_token", data["refresh_token"]),
+                token_type=payload.get("token_type", connection.token_type or "Bearer"),
+                expires_in=int(payload.get("expires_in", 3600)),
+                scope=_stringify_scopes(payload.get("scope", connection.scopes or [])),
+            )
+
+        connection.access_token = self.cipher.encrypt(tokens.access_token)
+        connection.refresh_token = self.cipher.encrypt(tokens.refresh_token)
+        connection.token_type = tokens.token_type
+        connection.scopes = tokens.scope
+        connection.expires_at = _now() + dt.timedelta(seconds=tokens.expires_in - 30)
+        session.add(connection)
+        session.flush()
+        session.refresh(connection)
+        return connection
+
+    def _fetch_updated_issues(
+        self, connection: JiraConnection, config: JiraProjectConfig
+    ) -> Iterable[Dict[str, Any]]:
+        if self.mock_mode:
+            if not os.path.isdir(FIXTURES_ROOT):
+                return
+            pages = sorted(
+                [p for p in os.listdir(FIXTURES_ROOT) if p.startswith("search_page")],
+                key=lambda name: name,
+            )
+            for page in pages:
+                with open(os.path.join(FIXTURES_ROOT, page), "r", encoding="utf-8") as handle:
+                    payload = json.load(handle)
+                for issue in payload.get("issues", []):
+                    yield issue
+            return
+
+        jql = config.default_jql or ""
+        if not jql:
+            keys = ",".join(config.project_keys)
+            jql = f"project in ({keys})"
+        if config.last_sync_at:
+            since = config.last_sync_at - dt.timedelta(minutes=5)
+            since_str = since.strftime("%Y-%m-%d %H:%M")
+            jql += f" AND updated >= '{since_str}'"
+
+        start_at = 0
+        more = True
+        while more:
+            response = self._request_with_retry(
+                "GET",
+                f"https://api.atlassian.com/ex/jira/{self._cloud_id_from_base(connection.cloud_base_url)}/rest/api/3/search",
+                headers=self._auth_headers(connection),
+                params={"jql": jql, "startAt": start_at, "maxResults": 100},
+            )
+            response.raise_for_status()
+            payload = response.json()
+            issues = payload.get("issues", [])
+            for issue in issues:
+                yield issue
+            total = payload.get("total", 0)
+            start_at += len(issues)
+            more = start_at < total and len(issues) > 0
+
+    def _request_with_retry(self, method: str, url: str, **kwargs: Any) -> requests.Response:
+        backoff_sequence = list(DEFAULT_RETRY_BACKOFF)
+        for attempt in range(len(backoff_sequence) + 1):
+            response = requests.request(method, url, timeout=30, **kwargs)
+            if response.status_code != 429:
+                return response
+            retry_after = response.headers.get("Retry-After")
+            delay = float(retry_after) if retry_after else backoff_sequence[min(attempt, len(backoff_sequence) - 1)]
+            time.sleep(min(delay, 5))
+        return response
+
+    def _cloud_id_from_base(self, base_url: str) -> str:
+        cleaned = base_url.rstrip("/")
+        return cleaned.split("//")[-1].split(".")[0]
+
+    def _auth_headers(self, connection: JiraConnection) -> Dict[str, str]:
+        token = self.cipher.decrypt(connection.access_token) or ""
+        return {"Authorization": f"Bearer {token}", "Accept": "application/json"}
+
+    def _upsert_issue(
+        self,
+        session: Session,
+        connection: JiraConnection,
+        issue_payload: Dict[str, Any],
+    ) -> Tuple[JiraIssue, bool]:
+        key = issue_payload.get("key")
+        fields = issue_payload.get("fields", {})
+        project_key = issue_payload.get("key", "").split("-")[0]
+        summary = fields.get("summary")
+        description = fields.get("description")
+        if isinstance(description, dict):
+            description = description.get("content") or json.dumps(description)
+        status_name = (fields.get("status") or {}).get("name")
+        priority_name = (fields.get("priority") or {}).get("name")
+        assignee = (fields.get("assignee") or {}).get("displayName")
+        reporter = (fields.get("reporter") or {}).get("displayName")
+        labels = fields.get("labels") or []
+        epic_key = None
+        if fields.get("epic"):
+            epic_key = fields["epic"].get("key")
+        sprint = None
+        if fields.get("sprint"):
+            sprint = fields["sprint"].get("name")
+        updated = _parse_datetime(fields.get("updated")) or _now()
+        url = f"{connection.cloud_base_url.rstrip('/')}/browse/{key}"
+
+        issue = (
+            session.execute(select(JiraIssue).where(JiraIssue.issue_key == key))
+            .scalars()
+            .one_or_none()
+        )
+
+        reindexed = False
+        if issue is None:
+            issue = JiraIssue(
+                connection_id=connection.id,
+                project_key=project_key,
+                issue_key=key,
+                summary=summary,
+                description=description,
+                status=status_name,
+                priority=priority_name,
+                assignee=assignee,
+                reporter=reporter,
+                labels=labels,
+                epic_key=epic_key,
+                sprint=sprint,
+                updated=updated,
+                url=url,
+                raw=issue_payload,
+            )
+            session.add(issue)
+            reindexed = True
+        else:
+            changed_fields = [
+                issue.summary != summary,
+                issue.description != description,
+                issue.status != status_name,
+                issue.priority != priority_name,
+                issue.assignee != assignee,
+                issue.updated != updated,
+            ]
+            reindexed = any(changed_fields)
+            issue.project_key = project_key
+            issue.summary = summary
+            issue.description = description
+            issue.status = status_name
+            issue.priority = priority_name
+            issue.assignee = assignee
+            issue.reporter = reporter
+            issue.labels = labels
+            issue.epic_key = epic_key
+            issue.sprint = sprint
+            issue.updated = updated
+            issue.url = url
+            issue.raw = issue_payload
+
+        if reindexed:
+            combined_text = "\n".join(
+                filter(
+                    None,
+                    [summary or "", description or "", " ".join(labels or [])],
+                )
+            )
+            self.vector_store.index_issue(
+                issue.issue_key,
+                combined_text,
+                {
+                    "issue_key": issue.issue_key,
+                    "summary": summary or "",
+                    "project": project_key,
+                    "status": status_name or "",
+                },
+            )
+            issue.indexed_at = _now()
+
+        session.flush()
+        session.refresh(issue)
+        return issue, reindexed
+
+    # ------------------------------------------------------------------
+    # Queries
+    def list_tasks(
+        self,
+        org_id: uuid.UUID,
+        assignee: Optional[str],
+        status: Optional[str],
+        project: Optional[str],
+        updated_since: Optional[str],
+        me_identifier: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        with session_scope() as session:
+            connection = (
+                session.execute(select(JiraConnection).where(JiraConnection.org_id == org_id))
+                .scalars()
+                .first()
+            )
+            if not connection:
+                return []
+
+            query = session.query(JiraIssue).join(JiraProjectConfig, JiraProjectConfig.connection_id == JiraIssue.connection_id)
+            query = query.filter(JiraProjectConfig.org_id == org_id)
+            if project:
+                query = query.filter(JiraIssue.project_key == project)
+            if status:
+                statuses = [item.strip() for item in status.split(",") if item.strip()]
+                if statuses:
+                    query = query.filter(JiraIssue.status.in_(statuses))
+            if updated_since:
+                try:
+                    since_dt = dt.datetime.fromisoformat(updated_since)
+                except ValueError:
+                    since_dt = dt.datetime.fromisoformat(updated_since + "T00:00:00")
+                query = query.filter(JiraIssue.updated >= since_dt)
+
+            assignee_value = assignee
+            if assignee == "me":
+                assignee_value = me_identifier or str(connection.user_id)
+            if assignee_value:
+                query = query.filter(JiraIssue.assignee == assignee_value)
+
+            results = []
+            for issue in query.order_by(JiraIssue.updated.desc()).all():
+                results.append(
+                    {
+                        "key": issue.issue_key,
+                        "title": issue.summary,
+                        "status": issue.status,
+                        "priority": issue.priority,
+                        "assignee": issue.assignee,
+                        "updated": issue.updated.isoformat() if issue.updated else None,
+                        "url": issue.url,
+                    }
+                )
+            return results
+
+    def search(self, org_id: uuid.UUID, query: str, project: Optional[str], top_k: int = 10) -> List[Dict[str, Any]]:
+        if not query:
+            return []
+        with session_scope() as session:
+            base_query = session.query(JiraIssue).join(JiraProjectConfig, JiraProjectConfig.connection_id == JiraIssue.connection_id)
+            base_query = base_query.filter(JiraProjectConfig.org_id == org_id)
+            if project:
+                base_query = base_query.filter(JiraIssue.project_key == project)
+            text_matches = (
+                base_query.filter(
+                    func.lower(JiraIssue.summary).contains(query.lower())
+                    | func.lower(JiraIssue.description).contains(query.lower())
+                )
+                .limit(top_k)
+                .all()
+            )
+            vector_scores = self.vector_store.search(query, limit=top_k)
+            scored: Dict[str, Tuple[float, JiraIssue]] = {}
+            for issue in text_matches:
+                scored[issue.issue_key] = (0.0, issue)
+            for issue_key, distance in vector_scores.items():
+                issue = (
+                    session.execute(select(JiraIssue).where(JiraIssue.issue_key == issue_key))
+                    .scalars()
+                    .one_or_none()
+                )
+                if issue is None:
+                    continue
+                score = distance
+                if issue.issue_key in scored:
+                    score = min(score, scored[issue.issue_key][0])
+                scored[issue.issue_key] = (score, issue)
+
+            ranked = sorted(scored.values(), key=lambda item: item[0])[:top_k]
+            return [self._issue_to_dict(issue) for _, issue in ranked]
+
+    def get_issue(self, org_id: uuid.UUID, key: str) -> Optional[Dict[str, Any]]:
+        with session_scope() as session:
+            issue = (
+                session.execute(
+                    select(JiraIssue)
+                    .join(JiraProjectConfig, JiraProjectConfig.connection_id == JiraIssue.connection_id)
+                    .where(
+                        JiraIssue.issue_key == key,
+                        JiraProjectConfig.org_id == org_id,
+                    )
+                )
+                .scalars()
+                .one_or_none()
+            )
+            if not issue:
+                return None
+            return self._issue_to_dict(issue, include_raw=True)
+
+    def _issue_to_dict(self, issue: JiraIssue, include_raw: bool = False) -> Dict[str, Any]:
+        payload = {
+            "key": issue.issue_key,
+            "project": issue.project_key,
+            "title": issue.summary,
+            "summary": issue.summary,
+            "description": issue.description,
+            "status": issue.status,
+            "priority": issue.priority,
+            "assignee": issue.assignee,
+            "reporter": issue.reporter,
+            "labels": issue.labels or [],
+            "epic_key": issue.epic_key,
+            "sprint": issue.sprint,
+            "updated": issue.updated.isoformat() if issue.updated else None,
+            "url": issue.url,
+        }
+        if include_raw:
+            payload["raw"] = issue.raw
+        return payload
+
+
+__all__ = ["JiraIntegrationService", "JiraSyncWorker", "OAuthTokens"]

--- a/backend/integrations/jira_service.py
+++ b/backend/integrations/jira_service.py
@@ -555,8 +555,12 @@ class JiraIntegrationService:
                 try:
                     since_dt = dt.datetime.fromisoformat(updated_since)
                 except ValueError:
-                    since_dt = dt.datetime.fromisoformat(updated_since + "T00:00:00")
-                query = query.filter(JiraIssue.updated >= since_dt)
+                    try:
+                        since_dt = dt.datetime.fromisoformat(updated_since + "T00:00:00")
+                    except ValueError:
+                        since_dt = None
+                if since_dt is not None:
+                    query = query.filter(JiraIssue.updated >= since_dt)
 
             assignee_value = assignee
             if assignee == "me":

--- a/backend/integrations/jira_vector_store.py
+++ b/backend/integrations/jira_vector_store.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import logging
+import os
+from typing import Dict, List, Optional
+
+try:
+    import chromadb  # type: ignore
+    from chromadb.config import Settings  # type: ignore
+    from chromadb.utils.embedding_functions import DefaultEmbeddingFunction  # type: ignore
+except Exception:  # pragma: no cover - fallback for tests without chromadb
+    chromadb = None
+
+    class Settings:  # type: ignore[override]
+        def __init__(self, persist_directory: Optional[str] = None) -> None:
+            self.persist_directory = persist_directory
+
+    class DefaultEmbeddingFunction:  # type: ignore[override]
+        def __call__(self, texts: List[str]) -> List[List[float]]:
+            return [[float(len(text))] for text in texts]
+
+
+log = logging.getLogger(__name__)
+
+
+class JiraIssueVectorStore:
+    """Vector index for Jira issues (summary + description + labels)."""
+
+    def __init__(self, collection: str = "jira_issues") -> None:
+        persist_dir = os.getenv("MEMORY_DB_PATH", "./memory_db")
+        self._fallback: Dict[str, Dict[str, str]] = {}
+        if chromadb is None:
+            self._client = None
+            self._collection = None
+            return
+
+        try:
+            self._client = chromadb.Client(Settings(persist_directory=persist_dir))
+            self._collection = self._client.get_or_create_collection(
+                collection,
+                embedding_function=DefaultEmbeddingFunction(),
+            )
+        except Exception as exc:  # pragma: no cover - fallback path
+            log.warning("Falling back to in-memory Chroma store: %s", exc)
+            self._client = chromadb.Client(Settings())
+            self._collection = self._client.get_or_create_collection(
+                collection,
+                embedding_function=DefaultEmbeddingFunction(),
+            )
+
+    def index_issue(self, issue_key: str, text: str, metadata: Dict[str, str]) -> None:
+        if not text.strip():
+            text = metadata.get("summary", "")
+        if self._collection is not None:
+            self._collection.upsert(
+                ids=[issue_key],
+                documents=[text],
+                metadatas=[metadata],
+            )
+            return
+
+        self._fallback[issue_key] = {"text": text, **metadata}
+
+    def delete(self, issue_key: str) -> None:
+        if self._collection is not None:
+            self._collection.delete(ids=[issue_key])
+            return
+        self._fallback.pop(issue_key, None)
+
+    def search(self, query: str, limit: int = 10) -> Dict[str, float]:
+        if not query.strip():
+            return {}
+        if self._collection is not None:
+            results = self._collection.query(query_texts=[query], n_results=limit)
+            ids = results.get("ids", [[]])[0]
+            distances = results.get("distances", [[]])[0] or []
+            scores: Dict[str, float] = {}
+            for issue_id, distance in zip(ids, distances):
+                scores[str(issue_id)] = float(distance)
+            return scores
+
+        scores: Dict[str, float] = {}
+        lowered = query.lower()
+        for issue_id, payload in self._fallback.items():
+            haystack = payload.get("text", "").lower()
+            if lowered in haystack:
+                scores[issue_id] = 0.0
+                if len(scores) >= limit:
+                    break
+        return scores
+
+
+__all__ = ["JiraIssueVectorStore"]

--- a/backend/server.py
+++ b/backend/server.py
@@ -20,8 +20,10 @@ CORS(app)
 # Ship-It PR: Add healthz blueprint
 from backend.healthz import bp as healthz_bp
 from backend.webhooks_jira import bp as jira_bp
+from backend.integrations.jira_routes import bp as jira_integration_bp
 app.register_blueprint(healthz_bp)
 app.register_blueprint(jira_bp)
+app.register_blueprint(jira_integration_bp)
 
 # Ship-It PR: Add middleware for rate limiting and cost tracking
 from backend.middleware import rate_limit, record_cost

--- a/tests/fixtures/jira/oauth_tokens.json
+++ b/tests/fixtures/jira/oauth_tokens.json
@@ -1,0 +1,7 @@
+{
+  "access_token": "mock-access-token",
+  "refresh_token": "mock-refresh-token",
+  "token_type": "Bearer",
+  "expires_in": 3600,
+  "scope": "read:jira-user read:jira-work offline_access"
+}

--- a/tests/fixtures/jira/search_page1.json
+++ b/tests/fixtures/jira/search_page1.json
@@ -1,0 +1,33 @@
+{
+  "issues": [
+    {
+      "id": "10001",
+      "key": "PROJ-1",
+      "fields": {
+        "summary": "Implement authentication",
+        "description": "Add OAuth support to application",
+        "status": {"name": "In Progress"},
+        "priority": {"name": "High"},
+        "assignee": {"displayName": "Alice"},
+        "reporter": {"displayName": "Bob"},
+        "labels": ["backend", "oauth"],
+        "updated": "2024-04-30T10:00:00.000+0000"
+      }
+    },
+    {
+      "id": "10002",
+      "key": "PROJ-2",
+      "fields": {
+        "summary": "Fix onboarding bug",
+        "description": "Resolve issue affecting new signups",
+        "status": {"name": "In Progress"},
+        "priority": {"name": "Medium"},
+        "assignee": {"displayName": "Charlie"},
+        "reporter": {"displayName": "Dana"},
+        "labels": ["bug"],
+        "updated": "2024-04-29T09:00:00.000+0000"
+      }
+    }
+  ],
+  "total": 3
+}

--- a/tests/fixtures/jira/search_page2.json
+++ b/tests/fixtures/jira/search_page2.json
@@ -1,0 +1,19 @@
+{
+  "issues": [
+    {
+      "id": "10003",
+      "key": "PROJ-3",
+      "fields": {
+        "summary": "Improve dashboard performance",
+        "description": "Optimize queries for analytics dashboard",
+        "status": {"name": "Done"},
+        "priority": {"name": "Low"},
+        "assignee": {"displayName": "Alice"},
+        "reporter": {"displayName": "Evan"},
+        "labels": ["performance"],
+        "updated": "2024-04-28T08:00:00.000+0000"
+      }
+    }
+  ],
+  "total": 3
+}

--- a/tests/test_jira_integration.py
+++ b/tests/test_jira_integration.py
@@ -1,0 +1,317 @@
+import json
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Dict, List
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from backend.db.base import session_scope
+from backend.db.models import JiraConnection, JiraProjectConfig
+from backend.db.utils import ensure_schema
+
+
+@pytest.fixture(autouse=True)
+def configure_env(monkeypatch, tmp_path):
+    db_url = f"sqlite:///{tmp_path}/jira.db"
+    monkeypatch.setenv("KNOWLEDGE_DATABASE_URL", db_url)
+    monkeypatch.setenv("MOCK_JIRA", "true")
+    monkeypatch.setenv("JIRA_SYNC_INLINE", "true")
+    monkeypatch.setenv("JIRA_CLIENT_ID", "test-client")
+    monkeypatch.setenv("JIRA_CLIENT_SECRET", "test-secret")
+    monkeypatch.setenv("JIRA_REDIRECT_URI", "http://localhost/callback")
+    monkeypatch.setenv("JIRA_ENCRYPTION_KEY", "integration-test-key")
+    ensure_schema()
+    yield
+
+
+def test_token_refresh(monkeypatch):
+    monkeypatch.setenv("MOCK_JIRA", "false")
+    from backend.integrations.jira_service import JiraIntegrationService, _now
+
+    service = JiraIntegrationService()
+    with session_scope() as session:
+        connection = JiraConnection(
+            org_id=service.resolve_context({})[0],
+            user_id=service.resolve_context({})[1],
+            cloud_base_url="https://example.atlassian.net",
+            client_id="test-client",
+            token_type="Bearer",
+            access_token=service.cipher.encrypt("stale"),
+            refresh_token=service.cipher.encrypt("refresh-old"),
+            expires_at=_now() - timedelta(minutes=1),
+            scopes=["read"],
+        )
+        session.add(connection)
+        session.flush()
+        connection_id = connection.id
+
+    class DummyResponse:
+        def __init__(self):
+            self._payload = {
+                "access_token": "new-access",
+                "refresh_token": "new-refresh",
+                "token_type": "Bearer",
+                "expires_in": 7200,
+                "scope": "read:jira-work",
+            }
+
+        def json(self):
+            return self._payload
+
+        def raise_for_status(self):
+            return None
+
+        status_code = 200
+
+    def fake_post(url, json=None, timeout=30):  # noqa: A002 - match requests signature
+        assert json["grant_type"] == "refresh_token"
+        return DummyResponse()
+
+    monkeypatch.setattr("requests.post", fake_post)
+
+    with session_scope() as session:
+        connection = session.get(JiraConnection, connection_id)
+        updated = service.ensure_access_token(session, connection)
+
+    assert service.cipher.decrypt(updated.access_token) == "new-access"
+    assert service.cipher.decrypt(updated.refresh_token) == "new-refresh"
+    assert updated.scopes == ["read:jira-work"]
+
+
+def test_upsert_issue_updates(monkeypatch):
+    from backend.integrations.jira_service import JiraIntegrationService
+
+    class StubVector:
+        def __init__(self):
+            self.calls: List[Dict[str, str]] = []
+
+        def index_issue(self, issue_key, text, metadata):
+            self.calls.append({"key": issue_key, "text": text, **metadata})
+
+        def search(self, query, limit=10):
+            return {}
+
+    service = JiraIntegrationService(vector_store=StubVector())
+    org_id, user_id = service.resolve_context({})
+
+    tokens = service.exchange_code_for_tokens("dummy")
+    connection = service.store_tokens(
+        org_id=org_id,
+        user_id=user_id,
+        cloud_base_url="https://example.atlassian.net",
+        tokens=tokens,
+    )
+
+    issue_payload = {
+        "key": "PROJ-99",
+        "fields": {
+            "summary": "Initial summary",
+            "description": "Initial description",
+            "status": {"name": "To Do"},
+            "priority": {"name": "Low"},
+            "assignee": {"displayName": "Alice"},
+            "updated": "2024-04-25T00:00:00.000+0000",
+        },
+    }
+
+    with session_scope() as session:
+        issue, reindexed = service._upsert_issue(session, connection, issue_payload)  # noqa: SLF001
+        assert reindexed is True
+        assert issue.summary == "Initial summary"
+
+    updated_payload = json.loads(json.dumps(issue_payload))
+    updated_payload["fields"]["summary"] = "Updated summary"
+    updated_payload["fields"]["updated"] = "2024-04-26T00:00:00.000+0000"
+
+    with session_scope() as session:
+        session.add(connection)
+        session.flush()
+        refreshed = session.get(JiraConnection, connection.id)
+        issue, reindexed = service._upsert_issue(session, refreshed, updated_payload)  # noqa: SLF001
+        assert reindexed is True
+        assert issue.summary == "Updated summary"
+    assert len(service.vector_store.calls) == 2
+
+
+def test_jql_pagination(monkeypatch):
+    monkeypatch.setenv("MOCK_JIRA", "false")
+    from backend.integrations.jira_service import JiraIntegrationService
+
+    from backend.integrations.jira_service import OAuthTokens
+
+    service = JiraIntegrationService()
+    service.mock_mode = False
+
+    tokens = OAuthTokens(
+        access_token="token",
+        refresh_token="refresh",
+        token_type="Bearer",
+        expires_in=3600,
+        scope=["read"],
+    )
+    connection = service.store_tokens(
+        org_id=service.resolve_context({})[0],
+        user_id=service.resolve_context({})[1],
+        cloud_base_url="https://example.atlassian.net",
+        tokens=tokens,
+    )
+
+    with session_scope() as session:
+        config = JiraProjectConfig(
+            org_id=connection.org_id,
+            connection_id=connection.id,
+            project_keys=["PROJ"],
+        )
+        session.add(config)
+        session.flush()
+        config_id = config.id
+
+    payloads = iter(
+        [
+            {"issues": [{"key": "PROJ-1", "fields": {"summary": "One"}}], "total": 2},
+            {"issues": [{"key": "PROJ-2", "fields": {"summary": "Two"}}], "total": 2},
+        ]
+    )
+
+    class DummyResponse:
+        def __init__(self, data):
+            self.data = data
+            self.status_code = 200
+
+        def json(self):
+            return self.data
+
+        def raise_for_status(self):
+            return None
+
+    service._request_with_retry = lambda *args, **kwargs: DummyResponse(next(payloads))  # type: ignore[attr-defined]
+
+    with session_scope() as session:
+        config = session.get(JiraProjectConfig, config_id)
+        issues = list(service._fetch_updated_issues(connection, config))  # noqa: SLF001
+    assert {issue["key"] for issue in issues} == {"PROJ-1", "PROJ-2"}
+
+
+def test_integration_flow():
+    from backend.integrations.jira_service import JiraIntegrationService
+
+    service = JiraIntegrationService()
+    org_id, user_id = service.resolve_context({})
+
+    start_payload = service.build_oauth_url()
+    assert "url" in start_payload
+
+    tokens = service.exchange_code_for_tokens("mock-code")
+    connection = service.store_tokens(
+        org_id=org_id,
+        user_id=user_id,
+        cloud_base_url="https://example.atlassian.net",
+        tokens=tokens,
+    )
+
+    config = service.update_project_config(
+        org_id=org_id,
+        connection_id=connection.id,
+        project_keys=["PROJ"],
+        board_ids=[],
+        default_jql=None,
+    )
+    assert config.project_keys == ["PROJ"]
+
+    summary = service.perform_sync(org_id)
+    assert summary["processed"] >= 3
+
+    status = service.get_status(org_id)
+    assert status["connected"] is True
+    assert status["projects"] == ["PROJ"]
+
+    tasks = service.list_tasks(org_id, "me", None, "PROJ", None, me_identifier="Alice")
+    assert any(task["assignee"] == "Alice" for task in tasks)
+
+    search_results = service.search(org_id, "OAuth", "PROJ")
+    assert any("oauth" in (item["description"] or "").lower() for item in search_results)
+
+    issue = service.get_issue(org_id, "PROJ-1")
+    assert issue["key"] == "PROJ-1"
+
+
+def test_load_sync_scalability(monkeypatch):
+    from backend.integrations.jira_service import JiraIntegrationService
+
+    class CountingVector:
+        def __init__(self):
+            self.count = 0
+
+        def index_issue(self, issue_key, text, metadata):
+            self.count += 1
+
+        def search(self, query, limit=10):
+            return {}
+
+    from backend.integrations.jira_service import OAuthTokens
+
+    from backend.db.models import JiraIssue
+
+    with session_scope() as session:
+        session.query(JiraIssue).delete()
+        session.query(JiraProjectConfig).delete()
+        session.query(JiraConnection).delete()
+
+    service = JiraIntegrationService(vector_store=CountingVector())
+    service.mock_mode = False
+
+    tokens = OAuthTokens(
+        access_token="token",
+        refresh_token="refresh",
+        token_type="Bearer",
+        expires_in=3600,
+        scope=["read"],
+    )
+    connection = service.store_tokens(
+        org_id=service.resolve_context({})[0],
+        user_id=service.resolve_context({})[1],
+        cloud_base_url="https://example.atlassian.net",
+        tokens=tokens,
+    )
+
+    with session_scope() as session:
+        config = JiraProjectConfig(
+            org_id=connection.org_id,
+            connection_id=connection.id,
+            project_keys=["PROJ"],
+            last_sync_at=datetime.now(timezone.utc) - timedelta(days=1),
+        )
+        session.add(config)
+        session.flush()
+        org_id = connection.org_id
+
+    def generator():
+        for idx in range(5000):
+            yield {
+                "key": f"PROJ-{idx}",
+                "fields": {
+                    "summary": f"Issue {idx}",
+                    "description": "Synthetic load issue",
+                    "status": {"name": "In Progress"},
+                    "priority": {"name": "Medium"},
+                    "assignee": {"displayName": "Load"},
+                    "updated": "2024-04-27T00:00:00.000+0000",
+                },
+            }
+
+    service._fetch_updated_issues = lambda *args, **kwargs: generator()  # type: ignore[attr-defined]
+    result = service.perform_sync(org_id)
+    assert result["processed"] == 5000
+    assert service.vector_store.count == 5000
+
+    with session_scope() as session:
+        count = session.query(JiraConnection).filter(JiraConnection.org_id == org_id).count()
+        assert count == 1
+        issue_count = session.query(JiraIssue).count()
+        assert issue_count >= 5000

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -98,6 +98,17 @@ def _install_stub_dependencies() -> None:
             InvalidTokenError=_StubInvalidTokenError,
         ),
     )
+
+    class _StubOpenAIChat:
+        def __init__(self):
+            self.completions = SimpleNamespace(create=lambda *args, **kwargs: _mock_chat_completion("stub"))
+
+    class _StubOpenAIClient:
+        def __init__(self, *args, **kwargs):
+            self.chat = _StubOpenAIChat()
+
+    sys.modules.pop("openai", None)
+    sys.modules.setdefault("openai", SimpleNamespace(OpenAI=_StubOpenAIClient))
 def test_backend_register_login_and_resume_flow(tmp_path, monkeypatch):
     monkeypatch.setenv("JWT_SECRET", "test-secret")
     backend_db = tmp_path / "backend.db"


### PR DESCRIPTION
## Summary
- add Jira OAuth flow, configuration, sync worker, and REST endpoints for Jira issue data
- create database tables and vector store helpers for Jira connections, configs, and issues
- add fixtures and comprehensive tests covering token refresh, sync pagination, search, and load behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68e6d348ded4832393e27c4052991f80