### PR TITLE
Fix spacing after stub dependency install in tests

### DIFF
--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -98,6 +98,8 @@ def _install_stub_dependencies() -> None:
             InvalidTokenError=_StubInvalidTokenError,
         ),
     )
+
+
 def test_backend_register_login_and_resume_flow(tmp_path, monkeypatch):
     monkeypatch.setenv("JWT_SECRET", "test-secret")
     backend_db = tmp_path / "backend.db"

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -99,7 +99,6 @@ def _install_stub_dependencies() -> None:
         ),
     )
 
-
 def test_backend_register_login_and_resume_flow(tmp_path, monkeypatch):
     monkeypatch.setenv("JWT_SECRET", "test-secret")
     backend_db = tmp_path / "backend.db"


### PR DESCRIPTION
## Summary
- add the missing blank line spacing after installing stub dependencies in `tests/test_services.py`

## Testing
- pytest tests/test_services.py *(fails: missing Flask dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e6fef5084883239a5ab31fb75afd9a