### PR TITLE
Add read-only GitHub integration with mock indexing and search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,7 @@ demo_*.py
 setup_*.sh
 data/*.db
 !tests/test_meeting_intelligence.py
+!tests/test_github_integration.py
 
 # Internal documentation
 INTERNAL_README.md

--- a/backend/db/models.py
+++ b/backend/db/models.py
@@ -3,7 +3,16 @@ from __future__ import annotations
 import uuid
 from datetime import datetime
 
-from sqlalchemy import Column, DateTime, ForeignKey, Integer, Numeric, String, Text
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    Numeric,
+    String,
+    Text,
+)
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.types import JSON
 
@@ -59,3 +68,78 @@ class ActionItem(Base):
     due_hint = Column(String(255))
     confidence = Column(Numeric)
     source_segment = Column(UUID(as_uuid=True), ForeignKey("transcript_segment.id"), nullable=True)
+
+
+class GHConnection(Base):
+    __tablename__ = "gh_connection"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    created_at = Column(DateTime(timezone=True), default=datetime.utcnow)
+    updated_at = Column(
+        DateTime(timezone=True), default=datetime.utcnow, onupdate=datetime.utcnow
+    )
+    installation_id = Column(String(255))
+    account_login = Column(String(255))
+    account_id = Column(String(255))
+    encrypted_access_token = Column(Text)
+    encrypted_refresh_token = Column(Text)
+    token_expires_at = Column(DateTime(timezone=True), nullable=True)
+    scopes = Column(Text)
+    mock = Column(Boolean, default=False)
+
+
+class GHRepo(Base):
+    __tablename__ = "gh_repo"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    connection_id = Column(
+        UUID(as_uuid=True), ForeignKey("gh_connection.id"), nullable=False
+    )
+    name = Column(String(255), nullable=False)
+    full_name = Column(String(512), nullable=False, unique=True)
+    default_branch = Column(String(255), nullable=True)
+    private = Column(Boolean, default=False)
+    url = Column(Text)
+    head_sha = Column(String(255))
+    last_index_at = Column(DateTime(timezone=True), nullable=True)
+    languages = _jsonb_column("languages")
+    top_paths = _jsonb_column("top_paths")
+    created_at = Column(DateTime(timezone=True), default=datetime.utcnow)
+    updated_at = Column(
+        DateTime(timezone=True), default=datetime.utcnow, onupdate=datetime.utcnow
+    )
+
+
+class GHFile(Base):
+    __tablename__ = "gh_file"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    repo_id = Column(UUID(as_uuid=True), ForeignKey("gh_repo.id"), nullable=False)
+    path = Column(Text, nullable=False)
+    sha = Column(String(255))
+    start_line = Column(Integer, nullable=False)
+    end_line = Column(Integer, nullable=False)
+    snippet = Column(Text, nullable=False)
+    embedding_id = Column(String(255))
+    created_at = Column(DateTime(timezone=True), default=datetime.utcnow)
+    updated_at = Column(
+        DateTime(timezone=True), default=datetime.utcnow, onupdate=datetime.utcnow
+    )
+
+
+class GHIssuePR(Base):
+    __tablename__ = "gh_issue_pr"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    repo_id = Column(UUID(as_uuid=True), ForeignKey("gh_repo.id"), nullable=False)
+    number = Column(Integer, nullable=False)
+    type = Column(String(16), nullable=False)
+    title = Column(Text, nullable=False)
+    state = Column(String(50))
+    updated_at = Column(DateTime(timezone=True), nullable=True)
+    url = Column(Text)
+    snippet = Column(Text)
+    embedding_id = Column(String(255))
+    created_at = Column(DateTime(timezone=True), default=datetime.utcnow)
+    ingested_at = Column(DateTime(timezone=True), default=datetime.utcnow)
+

--- a/backend/github_integration/chunking.py
+++ b/backend/github_integration/chunking.py
@@ -88,8 +88,6 @@ def iter_language_from_path(path: str) -> Iterable[str]:
         yield "C"
     elif lower.endswith(".scala"):
         yield "Scala"
-    elif lower.endswith(".rs"):
-        yield "Rust"
     elif lower.endswith(".md"):
         yield "Markdown"
     elif lower.endswith(".json"):

--- a/backend/github_integration/chunking.py
+++ b/backend/github_integration/chunking.py
@@ -1,0 +1,104 @@
+"""Utilities for chunking GitHub file contents into semantic blocks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List
+
+
+@dataclass(frozen=True)
+class CodeChunk:
+    path: str
+    start_line: int
+    end_line: int
+    text: str
+
+
+def chunk_source(
+    path: str,
+    content: str,
+    chunk_size: int = 160,
+    overlap: int = 20,
+) -> List[CodeChunk]:
+    """Split text content into ~``chunk_size`` line chunks with overlap.
+
+    The function keeps chunk boundaries aligned with line numbers which allows us
+    to build GitHub permalinks easily.  Overlap is used so that contextual lines
+    around boundaries remain searchable.
+    """
+
+    lines = content.splitlines()
+    if not lines:
+        return []
+
+    chunks: List[CodeChunk] = []
+    start = 0
+    total_lines = len(lines)
+    step = max(chunk_size - overlap, 1)
+
+    while start < total_lines:
+        end = min(start + chunk_size, total_lines)
+        snippet_lines = lines[start:end]
+        if snippet_lines:
+            chunk = CodeChunk(
+                path=path,
+                start_line=start + 1,
+                end_line=end,
+                text="\n".join(snippet_lines).strip()
+                or "\n".join(snippet_lines),
+            )
+            chunks.append(chunk)
+        if end == total_lines:
+            break
+        start = min(end, total_lines)
+        if overlap and start > overlap:
+            start -= overlap
+    return chunks
+
+
+def iter_language_from_path(path: str) -> Iterable[str]:
+    """Yield language heuristics based on file extension."""
+
+    lower = path.lower()
+    if lower.endswith(".py"):
+        yield "Python"
+    elif lower.endswith(".ts") or lower.endswith(".tsx"):
+        yield "TypeScript"
+    elif lower.endswith(".js") or lower.endswith(".jsx"):
+        yield "JavaScript"
+    elif lower.endswith(".go"):
+        yield "Go"
+    elif lower.endswith(".rs"):
+        yield "Rust"
+    elif lower.endswith(".java"):
+        yield "Java"
+    elif lower.endswith(".cs"):
+        yield "C#"
+    elif lower.endswith(".rb"):
+        yield "Ruby"
+    elif lower.endswith(".php"):
+        yield "PHP"
+    elif lower.endswith(".swift"):
+        yield "Swift"
+    elif lower.endswith(".kt") or lower.endswith(".kts"):
+        yield "Kotlin"
+    elif lower.endswith(".cpp") or lower.endswith(".cc") or lower.endswith(".cxx"):
+        yield "C++"
+    elif lower.endswith(".c"):
+        yield "C"
+    elif lower.endswith(".scala"):
+        yield "Scala"
+    elif lower.endswith(".rs"):
+        yield "Rust"
+    elif lower.endswith(".md"):
+        yield "Markdown"
+    elif lower.endswith(".json"):
+        yield "JSON"
+    elif lower.endswith(".yaml") or lower.endswith(".yml"):
+        yield "YAML"
+    elif lower.endswith(".sql"):
+        yield "SQL"
+
+
+__all__ = ["CodeChunk", "chunk_source", "iter_language_from_path"]
+

--- a/backend/github_integration/service.py
+++ b/backend/github_integration/service.py
@@ -1,0 +1,471 @@
+"""Service layer implementing the read-only GitHub integration features."""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import uuid
+from collections import Counter
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Tuple
+
+from sqlalchemy import func, select
+
+from backend.db import session_scope
+from backend.db.models import GHConnection, GHFile, GHIssuePR, GHRepo
+from backend.github_integration.chunking import chunk_source, iter_language_from_path
+from backend.security.crypto import TokenEncryptor
+
+
+def _now() -> datetime:
+    return datetime.utcnow()
+
+
+def _to_iso(dt: Optional[datetime]) -> Optional[str]:
+    if not dt:
+        return None
+    return dt.replace(microsecond=0).isoformat() + ("Z" if dt.tzinfo is None else "")
+
+
+def _parse_datetime(value: Optional[str]) -> Optional[datetime]:
+    if not value:
+        return None
+    try:
+        if value.endswith("Z"):
+            value = value[:-1] + "+00:00"
+        return datetime.fromisoformat(value)
+    except Exception:
+        return None
+
+
+def _tokenize(query: str) -> List[str]:
+    return [part.lower() for part in query.split() if part.strip()]
+
+
+def _score_text(tokens: Iterable[str], text: str, extra: str = "") -> float:
+    if not tokens:
+        return 0.0
+    lower_text = text.lower()
+    lower_extra = extra.lower()
+    score = 0.0
+    for token in tokens:
+        occurrences = lower_text.count(token)
+        score += occurrences * 1.5
+        if token in lower_extra:
+            score += 0.5
+    return score
+
+
+def _build_snippet(text: str, tokens: Iterable[str], limit: int = 320) -> str:
+    snippet = text.strip()
+    lower = snippet.lower()
+    for token in tokens:
+        idx = lower.find(token)
+        if idx != -1:
+            start = max(0, idx - 80)
+            end = min(len(snippet), idx + 80)
+            return snippet[start:end]
+    return snippet[:limit]
+
+
+@dataclass
+class IndexJobStatus:
+    id: str
+    repo_full_name: str
+    branch: str
+    mode: str
+    state: str = "queued"
+    progress: float = 0.0
+    errors: List[str] = field(default_factory=list)
+    started_at: Optional[datetime] = None
+    finished_at: Optional[datetime] = None
+    total_items: int = 0
+    processed_items: int = 0
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "index_id": self.id,
+            "state": self.state,
+            "progress": round(self.progress, 3),
+            "errors": self.errors,
+            "started_at": _to_iso(self.started_at),
+            "finished_at": _to_iso(self.finished_at),
+        }
+
+
+class GitHubIntegrationService:
+    def __init__(self) -> None:
+        self._encryptor = TokenEncryptor()
+        self._jobs: Dict[str, IndexJobStatus] = {}
+        self._lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    @property
+    def mock_enabled(self) -> bool:
+        return os.getenv("MOCK_GITHUB", "").lower() in {"1", "true", "yes", "on"}
+
+    @property
+    def fixtures_root(self) -> Path:
+        root = os.getenv("GITHUB_FIXTURES_PATH")
+        if root:
+            return Path(root)
+        return Path(__file__).resolve().parents[2] / "tests" / "fixtures" / "mock_github"
+
+    # ------------------------------------------------------------------
+    def start_oauth(self) -> Dict[str, str]:
+        client_id = os.getenv("GITHUB_CLIENT_ID", "mock-client-id")
+        redirect_uri = os.getenv("GITHUB_REDIRECT_URI", "http://localhost/callback")
+        scope = "read:user repo read:org"
+        if self.mock_enabled:
+            url = f"https://example.com/mock-github/oauth?client_id={client_id}"
+        else:
+            url = (
+                "https://github.com/login/oauth/authorize"
+                f"?client_id={client_id}&scope={scope.replace(' ', '%20')}"
+                f"&redirect_uri={redirect_uri}"
+            )
+        return {"authorization_url": url}
+
+    def complete_oauth(self, code: str) -> Dict[str, object]:
+        access_token = self._exchange_token(code)
+        with session_scope() as session:
+            connection = session.execute(select(GHConnection)).scalars().first()
+            if connection is None:
+                connection = GHConnection(mock=self.mock_enabled)
+                session.add(connection)
+                session.flush()
+            connection.encrypted_access_token = self._encryptor.encrypt(access_token)
+            connection.updated_at = _now()
+        return {"connected": True}
+
+    def status(self) -> Dict[str, object]:
+        with session_scope() as session:
+            connection = session.execute(select(GHConnection)).scalars().first()
+            connected = bool(connection and connection.encrypted_access_token)
+            repos_indexed = session.execute(
+                select(func.count()).select_from(GHRepo).where(GHRepo.last_index_at.isnot(None))
+            ).scalar_one()
+            last_index_at = session.execute(select(func.max(GHRepo.last_index_at))).scalar()
+        return {
+            "connected": connected,
+            "repos_indexed": int(repos_indexed or 0),
+            "last_index_at": _to_iso(last_index_at),
+        }
+
+    def list_repos(self) -> List[Dict[str, object]]:
+        repos_payload = self._fetch_repos()
+        results: List[Dict[str, object]] = []
+        with session_scope() as session:
+            connection = session.execute(select(GHConnection)).scalars().first()
+            if connection is None:
+                connection = GHConnection(mock=self.mock_enabled)
+                session.add(connection)
+                session.flush()
+            for repo_payload in repos_payload:
+                repo = self._upsert_repo(session, connection, repo_payload)
+                results.append(
+                    {
+                        "name": repo.name,
+                        "full_name": repo.full_name,
+                        "default_branch": repo.default_branch,
+                        "private": bool(repo.private),
+                        "url": repo.url,
+                    }
+                )
+        return results
+
+    def request_index(self, repo_full_name: str, branch: Optional[str] = None, mode: str = "api") -> Dict[str, str]:
+        branch = branch or "main"
+        index_id = str(uuid.uuid4())
+        job = IndexJobStatus(id=index_id, repo_full_name=repo_full_name, branch=branch, mode=mode)
+        with self._lock:
+            self._jobs[index_id] = job
+        thread = threading.Thread(
+            target=self._run_index_job,
+            args=(index_id, repo_full_name, branch, mode),
+            daemon=True,
+        )
+        thread.start()
+        return {"index_id": index_id}
+
+    def index_status(self, index_id: str) -> Dict[str, object]:
+        with self._lock:
+            job = self._jobs.get(index_id)
+        if job is None:
+            return {"state": "unknown", "progress": 0.0, "errors": ["index job not found"]}
+        return job.to_dict()
+
+    def search_code(
+        self, query: str, repo: Optional[str] = None, path: Optional[str] = None, top_k: int = 10
+    ) -> List[Dict[str, object]]:
+        tokens = _tokenize(query)
+        if not tokens:
+            return []
+        stmt = select(GHFile, GHRepo).join(GHRepo, GHRepo.id == GHFile.repo_id)
+        if repo:
+            stmt = stmt.where(GHRepo.full_name == repo)
+        if path:
+            like = f"%{path}%"
+            stmt = stmt.where(GHFile.path.like(like))
+        with session_scope() as session:
+            rows = session.execute(stmt).all()
+        scored: List[Tuple[float, GHFile, GHRepo]] = []
+        for file_row, repo_row in rows:
+            score = _score_text(tokens, file_row.snippet, file_row.path)
+            if score <= 0:
+                continue
+            scored.append((score, file_row, repo_row))
+        scored.sort(key=lambda item: item[0], reverse=True)
+        results: List[Dict[str, object]] = []
+        for score, file_row, repo_row in scored[:top_k]:
+            sha = file_row.sha or repo_row.head_sha or repo_row.default_branch or "main"
+            permalink = (
+                f"https://github.com/{repo_row.full_name}/blob/{sha}/{file_row.path}"
+                f"#L{file_row.start_line}-L{file_row.end_line}"
+            )
+            snippet = _build_snippet(file_row.snippet, tokens)
+            results.append(
+                {
+                    "repo": repo_row.full_name,
+                    "path": file_row.path,
+                    "start_line": file_row.start_line,
+                    "end_line": file_row.end_line,
+                    "sha": sha,
+                    "permalink": permalink,
+                    "snippet": snippet,
+                    "score": round(score, 3),
+                }
+            )
+        return results
+
+    def search_issues(
+        self,
+        query: str,
+        repo: Optional[str] = None,
+        updated_since: Optional[str] = None,
+        top_k: int = 10,
+    ) -> List[Dict[str, object]]:
+        tokens = _tokenize(query)
+        if not tokens:
+            return []
+        stmt = select(GHIssuePR, GHRepo).join(GHRepo, GHIssuePR.repo_id == GHRepo.id)
+        if repo:
+            stmt = stmt.where(GHRepo.full_name == repo)
+        if updated_since:
+            cutoff = _parse_datetime(updated_since)
+            if cutoff:
+                stmt = stmt.where(GHIssuePR.updated_at >= cutoff)
+        with session_scope() as session:
+            rows = session.execute(stmt).all()
+        scored: List[Tuple[float, GHIssuePR, GHRepo]] = []
+        for issue_row, repo_row in rows:
+            body = issue_row.snippet or ""
+            composite = f"{issue_row.title}\n{body}"
+            score = _score_text(tokens, composite, repo_row.full_name)
+            if score <= 0:
+                continue
+            scored.append((score, issue_row, repo_row))
+        scored.sort(key=lambda item: item[0], reverse=True)
+        results: List[Dict[str, object]] = []
+        for score, issue_row, repo_row in scored[:top_k]:
+            snippet = _build_snippet(issue_row.snippet or issue_row.title, tokens)
+            results.append(
+                {
+                    "number": issue_row.number,
+                    "type": issue_row.type,
+                    "title": issue_row.title,
+                    "state": issue_row.state,
+                    "updated": _to_iso(issue_row.updated_at),
+                    "url": issue_row.url,
+                    "snippet": snippet,
+                    "score": round(score, 3),
+                }
+            )
+        return results
+
+    def repo_context(self, repo_full_name: str) -> Dict[str, object]:
+        stmt = select(GHRepo).where(GHRepo.full_name == repo_full_name)
+        with session_scope() as session:
+            repo = session.execute(stmt).scalars().first()
+        if repo is None:
+            return {"error": "repo not found"}
+        languages_data = []
+        if isinstance(repo.languages, dict):
+            for lang, count in sorted(repo.languages.items(), key=lambda item: item[1], reverse=True):
+                languages_data.append({"language": lang, "count": count})
+        elif isinstance(repo.languages, list):
+            languages_data = repo.languages
+        return {
+            "languages": languages_data,
+            "top_paths": repo.top_paths or [],
+            "last_index_at": _to_iso(repo.last_index_at),
+        }
+
+    # ------------------------------------------------------------------
+    def _exchange_token(self, code: str) -> str:
+        if self.mock_enabled:
+            return f"mock-token-{code}"
+        # In production this would exchange the OAuth code with GitHub.
+        # We keep a placeholder implementation for now.
+        return f"token-{code}"
+
+    def _fetch_repos(self) -> List[Dict[str, object]]:
+        if self.mock_enabled:
+            path = self.fixtures_root / "repos.json"
+            data = json.loads(path.read_text()) if path.exists() else []
+            return data
+        return []
+
+    def _upsert_repo(
+        self, session, connection: GHConnection, payload: Dict[str, object]
+    ) -> GHRepo:
+        repo = (
+            session.execute(select(GHRepo).where(GHRepo.full_name == payload["full_name"]))
+            .scalars()
+            .first()
+        )
+        if repo is None:
+            repo = GHRepo(
+                connection_id=connection.id,
+                name=payload.get("name", payload["full_name"]).split("/")[-1],
+                full_name=payload["full_name"],
+            )
+            session.add(repo)
+            session.flush()
+        repo.name = payload.get("name", repo.name)
+        repo.default_branch = payload.get("default_branch", repo.default_branch)
+        repo.private = bool(payload.get("private", False))
+        repo.url = payload.get("url") or payload.get("html_url")
+        repo.updated_at = _now()
+        return repo
+
+    def _run_index_job(self, index_id: str, repo_full_name: str, branch: str, mode: str) -> None:
+        self._update_job(index_id, state="running", started_at=_now())
+        try:
+            repo_info = self._prepare_repo(repo_full_name)
+            self._ingest_repo(index_id, repo_info)
+            self._update_job(index_id, state="completed", progress=1.0, finished_at=_now())
+        except Exception as exc:  # pragma: no cover - defensive
+            self._update_job(
+                index_id,
+                state="failed",
+                finished_at=_now(),
+                errors=[str(exc)],
+            )
+
+    def _prepare_repo(self, repo_full_name: str) -> Tuple[GHRepo, Path]:
+        with session_scope() as session:
+            repo = (
+                session.execute(select(GHRepo).where(GHRepo.full_name == repo_full_name))
+                .scalars()
+                .first()
+            )
+            if repo is None:
+                raise ValueError(f"Unknown repository {repo_full_name}")
+        if self.mock_enabled:
+            repo_path = self.fixtures_root / "repos" / repo_full_name.replace("/", "__")
+            if not repo_path.exists():
+                raise FileNotFoundError(f"Missing mock repo fixture for {repo_full_name}")
+            return repo, repo_path
+        raise RuntimeError("Non-mock GitHub indexing is not implemented in this environment")
+
+    def _ingest_repo(self, index_id: str, repo_info: Tuple[GHRepo, Path]) -> None:
+        repo, repo_path = repo_info
+        files: List[Path] = [p for p in repo_path.rglob("*") if p.is_file()]
+        total = len(files) or 1
+        language_counter: Counter[str] = Counter()
+        path_counter: Counter[str] = Counter()
+        file_rows: List[Dict[str, object]] = []
+        for idx, file_path in enumerate(files, start=1):
+            data = file_path.read_bytes()
+            if len(data) > 256 * 1024:
+                self._update_progress(index_id, idx, total)
+                continue
+            if b"\0" in data:
+                self._update_progress(index_id, idx, total)
+                continue
+            text = data.decode("utf-8", errors="ignore")
+            rel_path = str(file_path.relative_to(repo_path))
+            for lang in iter_language_from_path(rel_path):
+                language_counter[lang] += 1
+            parent = file_path.parent.relative_to(repo_path)
+            path_counter[str(parent) or "."] += 1
+            for chunk in chunk_source(rel_path, text):
+                file_rows.append(
+                    {
+                        "path": chunk.path,
+                        "start": chunk.start_line,
+                        "end": chunk.end_line,
+                        "snippet": chunk.text,
+                        "sha": uuid.uuid5(uuid.NAMESPACE_URL, f"{rel_path}:{chunk.start_line}:{chunk.end_line}").hex,
+                    }
+                )
+            self._update_progress(index_id, idx, total)
+
+        with session_scope() as session:
+            repo_db = session.get(GHRepo, repo.id)
+            if repo_db is None:
+                raise ValueError("Repository disappeared during indexing")
+            session.query(GHFile).filter(GHFile.repo_id == repo.id).delete(synchronize_session=False)
+            for row in file_rows:
+                gh_file = GHFile(
+                    repo_id=repo.id,
+                    path=row["path"],
+                    start_line=row["start"],
+                    end_line=row["end"],
+                    snippet=row["snippet"],
+                    sha=row["sha"],
+                )
+                session.add(gh_file)
+
+            issues_payload = self._load_issues(repo_db.full_name)
+            session.query(GHIssuePR).filter(GHIssuePR.repo_id == repo.id).delete(
+                synchronize_session=False
+            )
+            for payload in issues_payload:
+                issue = GHIssuePR(
+                    repo_id=repo.id,
+                    number=payload["number"],
+                    type=payload.get("type", "issue"),
+                    title=payload.get("title", ""),
+                    state=payload.get("state"),
+                    updated_at=_parse_datetime(payload.get("updated_at")),
+                    url=payload.get("url"),
+                    snippet=payload.get("body", "")[:600],
+                )
+                session.add(issue)
+
+            repo_db.languages = dict(language_counter)
+            repo_db.top_paths = [path for path, _ in path_counter.most_common(5)]
+            repo_db.last_index_at = _now()
+            repo_db.head_sha = uuid.uuid5(uuid.NAMESPACE_URL, repo_db.full_name).hex
+
+    def _load_issues(self, repo_full_name: str) -> List[Dict[str, object]]:
+        if not self.mock_enabled:
+            return []
+        issues_dir = self.fixtures_root / "issues"
+        path = issues_dir / f"{repo_full_name.replace('/', '__')}.json"
+        if not path.exists():
+            return []
+        return json.loads(path.read_text())
+
+    def _update_progress(self, index_id: str, processed: int, total: int) -> None:
+        progress = min(max(processed / float(total), 0.0), 1.0)
+        self._update_job(index_id, progress=progress, processed_items=processed, total_items=total)
+
+    def _update_job(self, index_id: str, **updates) -> None:
+        with self._lock:
+            job = self._jobs.get(index_id)
+            if not job:
+                return
+            for key, value in updates.items():
+                setattr(job, key, value)
+
+
+github_integration_service = GitHubIntegrationService()
+
+__all__ = ["GitHubIntegrationService", "github_integration_service"]
+

--- a/backend/security/crypto.py
+++ b/backend/security/crypto.py
@@ -1,0 +1,97 @@
+"""Utility helpers for encrypting and decrypting sensitive secrets.
+
+This module intentionally keeps the dependency surface small.  When the
+``cryptography`` package is available we rely on :class:`~cryptography.fernet.Fernet`
+for strong symmetric encryption.  In environments where that dependency is not
+installed we fall back to a lightweight XOR-based cipher that still keeps the
+values unreadable at rest while remaining reversible.  The fallback is not meant
+to be bullet proof, but it satisfies the requirement of avoiding plaintext
+tokens in the database during development and tests.
+
+The encryption key is derived from ``TOKEN_ENCRYPTION_SECRET`` (or
+``GITHUB_ENCRYPTION_SECRET`` for backwards compatibility).  The derivation uses
+SHA-256 so callers can provide arbitrary length secrets.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+try:  # pragma: no cover - exercised when cryptography is installed
+    from cryptography.fernet import Fernet, InvalidToken
+except Exception:  # pragma: no cover - fallback path for light-weight envs
+    Fernet = None  # type: ignore[assignment]
+
+    class InvalidToken(Exception):
+        """Placeholder exception so callers do not need conditional imports."""
+
+
+def _derive_key(secret: str) -> bytes:
+    """Derive a stable 32-byte key from the provided secret string."""
+
+    digest = hashlib.sha256(secret.encode("utf-8")).digest()
+    return base64.urlsafe_b64encode(digest)
+
+
+@dataclass
+class TokenEncryptor:
+    """Small helper that wraps encryption/decryption operations."""
+
+    secret: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        env_secret = (
+            self.secret
+            or os.getenv("TOKEN_ENCRYPTION_SECRET")
+            or os.getenv("GITHUB_ENCRYPTION_SECRET")
+            or "mentor-app-secret"
+        )
+        derived = _derive_key(env_secret)
+        if Fernet is not None:  # pragma: no cover - depends on optional dep
+            self._fernet = Fernet(derived)
+            self._key_bytes: Optional[bytes] = None
+        else:  # lightweight reversible fallback for tests
+            self._fernet = None
+            self._key_bytes = hashlib.sha256(env_secret.encode("utf-8")).digest()
+
+    # --- Public API -----------------------------------------------------
+    def encrypt(self, value: str | None) -> str:
+        if not value:
+            return ""
+        if self._fernet is not None:  # pragma: no cover - optional dependency
+            token = self._fernet.encrypt(value.encode("utf-8"))
+            return token.decode("utf-8")
+        assert self._key_bytes is not None
+        xor_bytes = self._xor_with_key(value.encode("utf-8"))
+        return base64.urlsafe_b64encode(xor_bytes).decode("utf-8")
+
+    def decrypt(self, value: str | None) -> str:
+        if not value:
+            return ""
+        if self._fernet is not None:  # pragma: no cover - optional dependency
+            try:
+                plain = self._fernet.decrypt(value.encode("utf-8"))
+            except InvalidToken:
+                return ""
+            return plain.decode("utf-8")
+        assert self._key_bytes is not None
+        try:
+            decoded = base64.urlsafe_b64decode(value.encode("utf-8"))
+        except Exception:
+            return ""
+        plain = self._xor_with_key(decoded)
+        return plain.decode("utf-8", errors="ignore")
+
+    # --- Internal helpers -----------------------------------------------
+    def _xor_with_key(self, data: bytes) -> bytes:
+        assert self._key_bytes is not None
+        key = self._key_bytes
+        return bytes((byte ^ key[i % len(key)]) for i, byte in enumerate(data))
+
+
+__all__ = ["TokenEncryptor"]
+

--- a/migrations/003_github_integration_tables.sql
+++ b/migrations/003_github_integration_tables.sql
@@ -1,0 +1,69 @@
+-- GitHub integration storage
+
+CREATE TABLE IF NOT EXISTS gh_connection (
+    id TEXT PRIMARY KEY,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    installation_id TEXT,
+    account_login TEXT,
+    account_id TEXT,
+    encrypted_access_token TEXT,
+    encrypted_refresh_token TEXT,
+    token_expires_at TIMESTAMP,
+    scopes TEXT,
+    mock INTEGER DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS gh_repo (
+    id TEXT PRIMARY KEY,
+    connection_id TEXT NOT NULL REFERENCES gh_connection(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    full_name TEXT NOT NULL UNIQUE,
+    default_branch TEXT,
+    private INTEGER DEFAULT 0,
+    url TEXT,
+    head_sha TEXT,
+    last_index_at TIMESTAMP,
+    languages TEXT,
+    top_paths TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_gh_repo_connection ON gh_repo(connection_id);
+
+CREATE TABLE IF NOT EXISTS gh_file (
+    id TEXT PRIMARY KEY,
+    repo_id TEXT NOT NULL REFERENCES gh_repo(id) ON DELETE CASCADE,
+    path TEXT NOT NULL,
+    sha TEXT,
+    start_line INTEGER NOT NULL,
+    end_line INTEGER NOT NULL,
+    snippet TEXT NOT NULL,
+    embedding_id TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_gh_file_repo ON gh_file(repo_id);
+CREATE INDEX IF NOT EXISTS idx_gh_file_repo_path ON gh_file(repo_id, path);
+
+CREATE TABLE IF NOT EXISTS gh_issue_pr (
+    id TEXT PRIMARY KEY,
+    repo_id TEXT NOT NULL REFERENCES gh_repo(id) ON DELETE CASCADE,
+    number INTEGER NOT NULL,
+    type TEXT NOT NULL,
+    title TEXT NOT NULL,
+    state TEXT,
+    updated_at TIMESTAMP,
+    url TEXT,
+    snippet TEXT,
+    embedding_id TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    ingested_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(repo_id, number, type)
+);
+
+CREATE INDEX IF NOT EXISTS idx_gh_issue_repo ON gh_issue_pr(repo_id);
+CREATE INDEX IF NOT EXISTS idx_gh_issue_updated ON gh_issue_pr(repo_id, updated_at);
+

--- a/migrations/003_github_integration_tables.sql
+++ b/migrations/003_github_integration_tables.sql
@@ -2,14 +2,14 @@
 
 CREATE TABLE IF NOT EXISTS gh_connection (
     id TEXT PRIMARY KEY,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
     installation_id TEXT,
     account_login TEXT,
     account_id TEXT,
     encrypted_access_token TEXT,
     encrypted_refresh_token TEXT,
-    token_expires_at TIMESTAMP,
+    token_expires_at TIMESTAMPTZ,
     scopes TEXT,
     mock INTEGER DEFAULT 0
 );
@@ -23,11 +23,11 @@ CREATE TABLE IF NOT EXISTS gh_repo (
     private INTEGER DEFAULT 0,
     url TEXT,
     head_sha TEXT,
-    last_index_at TIMESTAMP,
-    languages TEXT,
-    top_paths TEXT,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    last_index_at TIMESTAMPTZ,
+    languages JSONB,
+    top_paths JSONB,
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
 );
 
 CREATE INDEX IF NOT EXISTS idx_gh_repo_connection ON gh_repo(connection_id);
@@ -41,8 +41,8 @@ CREATE TABLE IF NOT EXISTS gh_file (
     end_line INTEGER NOT NULL,
     snippet TEXT NOT NULL,
     embedding_id TEXT,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
 );
 
 CREATE INDEX IF NOT EXISTS idx_gh_file_repo ON gh_file(repo_id);
@@ -55,12 +55,12 @@ CREATE TABLE IF NOT EXISTS gh_issue_pr (
     type TEXT NOT NULL,
     title TEXT NOT NULL,
     state TEXT,
-    updated_at TIMESTAMP,
+    updated_at TIMESTAMPTZ,
     url TEXT,
     snippet TEXT,
     embedding_id TEXT,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    ingested_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    ingested_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
     UNIQUE(repo_id, number, type)
 );
 

--- a/tests/fixtures/mock_github/issues/octo-org__demo-repo.json
+++ b/tests/fixtures/mock_github/issues/octo-org__demo-repo.json
@@ -1,0 +1,20 @@
+[
+  {
+    "number": 42,
+    "type": "issue",
+    "title": "Improve Fibonacci performance",
+    "state": "open",
+    "updated_at": "2024-05-01T12:00:00Z",
+    "url": "https://github.com/octo-org/demo-repo/issues/42",
+    "body": "The fibonacci helper should memoize intermediate results to avoid redundant calculations when depth is large."
+  },
+  {
+    "number": 17,
+    "type": "pull_request",
+    "title": "Add CLI interface",
+    "state": "closed",
+    "updated_at": "2024-04-15T09:30:00Z",
+    "url": "https://github.com/octo-org/demo-repo/pull/17",
+    "body": "Implements a Typer-based CLI for invoking the summary builder."
+  }
+]

--- a/tests/fixtures/mock_github/repos.json
+++ b/tests/fixtures/mock_github/repos.json
@@ -1,0 +1,9 @@
+[
+  {
+    "name": "demo-repo",
+    "full_name": "octo-org/demo-repo",
+    "default_branch": "main",
+    "private": false,
+    "html_url": "https://github.com/octo-org/demo-repo"
+  }
+]

--- a/tests/fixtures/mock_github/repos/octo-org__demo-repo/README.md
+++ b/tests/fixtures/mock_github/repos/octo-org__demo-repo/README.md
@@ -1,0 +1,5 @@
+# Demo Repo
+
+This repository demonstrates the GitHub integration fixtures.
+
+It contains a small Python service with utilities that are used in the tests.

--- a/tests/fixtures/mock_github/repos/octo-org__demo-repo/docs/usage.md
+++ b/tests/fixtures/mock_github/repos/octo-org__demo-repo/docs/usage.md
@@ -1,0 +1,9 @@
+# Usage
+
+Run the main script with a JSON configuration file to build a runtime summary:
+
+```bash
+python -m src.main --config config.json
+```
+
+The configuration file accepts ``depth`` and ``author`` keys.

--- a/tests/fixtures/mock_github/repos/octo-org__demo-repo/src/main.py
+++ b/tests/fixtures/mock_github/repos/octo-org__demo-repo/src/main.py
@@ -1,0 +1,19 @@
+"""Entry point for the demo repo."""
+
+from .utils import fibonacci, read_config
+
+
+def build_summary(config_path: str) -> str:
+    """Build a runtime summary using the configuration file."""
+
+    config = read_config(config_path)
+    sequence = fibonacci(config.get("depth", 5))
+    lines = ["Demo Repository Runtime Summary:"]
+    lines.append(f"Depth: {config.get('depth', 5)}")
+    lines.append(f"Author: {config.get('author', 'unknown')}")
+    lines.append(f"Fibonacci: {', '.join(str(num) for num in sequence)}")
+    return "\n".join(lines)
+
+
+if __name__ == "__main__":
+    print(build_summary("./config.json"))

--- a/tests/fixtures/mock_github/repos/octo-org__demo-repo/src/utils.py
+++ b/tests/fixtures/mock_github/repos/octo-org__demo-repo/src/utils.py
@@ -1,0 +1,27 @@
+"""Utility helpers used within the demo repository."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List
+
+
+def fibonacci(depth: int) -> List[int]:
+    """Return ``depth`` elements of the fibonacci sequence."""
+
+    if depth <= 0:
+        return []
+    sequence = [0, 1]
+    while len(sequence) < depth:
+        sequence.append(sequence[-1] + sequence[-2])
+    return sequence[:depth]
+
+
+def read_config(path: str) -> Dict[str, object]:
+    """Read a JSON config file; return defaults when missing."""
+
+    config_path = Path(path)
+    if not config_path.exists():
+        return {"depth": 5, "author": "fixtures"}
+    return json.loads(config_path.read_text())

--- a/tests/test_github_integration.py
+++ b/tests/test_github_integration.py
@@ -1,0 +1,160 @@
+import importlib
+import sys
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from backend.github_integration.chunking import chunk_source
+
+
+@pytest.fixture
+def github_fixture_env(monkeypatch, tmp_path):
+    pytest.importorskip("sqlalchemy")
+    fixtures = Path(__file__).resolve().parent / "fixtures" / "mock_github"
+    monkeypatch.setenv("MOCK_GITHUB", "true")
+    monkeypatch.setenv("TOKEN_ENCRYPTION_SECRET", "test-secret")
+    monkeypatch.setenv("GITHUB_FIXTURES_PATH", str(fixtures))
+    db_url = f"sqlite:///{tmp_path/'github.db'}"
+    monkeypatch.setenv("KNOWLEDGE_DATABASE_URL", db_url)
+
+    import backend.db.base as db_base
+    from backend.db import Base
+
+    db_base._engine = None  # type: ignore[attr-defined]
+    db_base._SessionLocal = None  # type: ignore[attr-defined]
+    engine = db_base.get_engine(db_url)
+    Base.metadata.create_all(engine)
+
+    service_module = importlib.reload(importlib.import_module("backend.github_integration.service"))
+    yield service_module
+
+
+def test_chunking_preserves_line_spans():
+    source = "\n".join(f"line {i}" for i in range(1, 301))
+    chunks = chunk_source("demo.py", source, chunk_size=120, overlap=20)
+    assert chunks[0].start_line == 1
+    assert chunks[0].end_line == 120
+    assert chunks[1].start_line == 101
+    assert chunks[-1].end_line == 300
+
+
+def test_index_and_search_flow(github_fixture_env):
+    service_module = github_fixture_env
+    assert service_module.github_integration_service is not None
+
+    approvals_stub = SimpleNamespace(
+        approvals=SimpleNamespace(
+            list=lambda: [], get=lambda *a, **k: None, resolve=lambda *a, **k: {}
+        )
+    )
+    approval_worker_stub = SimpleNamespace(
+        on_approval_resolved=lambda *a, **k: {},
+        start_worker_thread=lambda: None,
+        set_dry_run_mode=lambda *a, **k: None,
+        get_integration_status=lambda: {},
+    )
+    watcher_stub = SimpleNamespace(handle_github_webhook=lambda *a, **k: None)
+
+    sys.modules["backend.approvals"] = approvals_stub
+    sys.modules["backend.approval_worker"] = approval_worker_stub
+    sys.modules["backend.watchers.ci_watcher"] = watcher_stub
+
+    server_module = importlib.reload(importlib.import_module("backend.server"))
+    client = server_module.app.test_client()
+
+    start_resp = client.post("/api/integrations/github/oauth/start")
+    assert start_resp.status_code == 200
+    assert "authorization_url" in start_resp.get_json()
+
+    callback_resp = client.get("/api/integrations/github/oauth/callback", query_string={"code": "demo"})
+    assert callback_resp.status_code == 200
+    assert callback_resp.get_json()["connected"] is True
+
+    status_resp = client.get("/api/integrations/github/status")
+    assert status_resp.status_code == 200
+    assert status_resp.get_json()["connected"] is True
+
+    repos_resp = client.get("/api/github/repos")
+    assert repos_resp.status_code == 200
+    repos_payload = repos_resp.get_json()["repos"]
+    assert len(repos_payload) == 1
+    repo_full_name = repos_payload[0]["full_name"]
+
+    index_resp = client.post(
+        "/api/github/index", json={"repo_full_name": repo_full_name, "mode": "git"}
+    )
+    assert index_resp.status_code == 202
+    index_id = index_resp.get_json()["index_id"]
+
+    for _ in range(50):
+        poll = client.get(f"/api/github/index/{index_id}/status")
+        assert poll.status_code == 200
+        payload = poll.get_json()
+        if payload["state"] in {"completed", "failed"}:
+            break
+        time.sleep(0.1)
+    else:
+        pytest.fail("index job did not finish")
+
+    assert payload["state"] == "completed"
+    assert payload["progress"] == pytest.approx(1.0)
+
+    from backend.db import session_scope
+    from backend.db.models import GHFile, GHIssuePR, GHRepo
+
+    with session_scope() as session:
+        assert session.query(GHRepo).count() == 1
+        file_count = session.query(GHFile).count()
+        issue_count = session.query(GHIssuePR).count()
+
+    assert file_count > 0
+    assert issue_count == 2
+
+    code_search = client.get(
+        "/api/github/search/code",
+        query_string={"q": "fibonacci", "repo": repo_full_name, "top_k": 5},
+    )
+    assert code_search.status_code == 200
+    code_results = code_search.get_json()["results"]
+    assert code_results
+    assert any("fibonacci" in result["snippet"].lower() for result in code_results)
+    assert code_results[0]["permalink"].startswith("https://github.com/")
+
+    issues_search = client.get(
+        "/api/github/search/issues",
+        query_string={"q": "fibonacci", "repo": repo_full_name, "top_k": 5},
+    )
+    assert issues_search.status_code == 200
+    issues_results = issues_search.get_json()["results"]
+    assert len(issues_results) >= 1
+    assert issues_results[0]["url"].startswith("https://github.com/")
+
+    context_resp = client.get(f"/api/github/repos/{repo_full_name}/context")
+    assert context_resp.status_code == 200
+    context_payload = context_resp.get_json()
+    assert context_payload["languages"]
+    assert context_payload["top_paths"]
+    assert context_payload["last_index_at"]
+
+    # Re-index the same repository to ensure metadata is refreshed rather than duplicated.
+    second_index = client.post(
+        "/api/github/index", json={"repo_full_name": repo_full_name, "mode": "api"}
+    )
+    second_id = second_index.get_json()["index_id"]
+    for _ in range(50):
+        poll = client.get(f"/api/github/index/{second_id}/status")
+        state = poll.get_json()["state"]
+        if state in {"completed", "failed"}:
+            break
+        time.sleep(0.1)
+    assert state == "completed"
+
+    with session_scope() as session:
+        assert session.query(GHFile).count() == file_count
+        assert session.query(GHIssuePR).count() == issue_count


### PR DESCRIPTION
## Summary
- add database models, migrations, and secure token helper to support GitHub connections and repositories
- implement GitHub integration service with OAuth endpoints, indexing worker, search, and repo context APIs
- provide mock fixtures and tests covering chunking, indexing, and search flows using the Flask server

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e983b683048323b39fba1d07f27d04